### PR TITLE
feat: [P3] Audit log rotation (currently unbounded)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "yazl": "^3.3.1",
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.14",
         "@types/bun": "latest",
         "@types/node-forge": "^1.3.14",
         "@types/yauzl": "^2.10.3",
@@ -62,6 +63,24 @@
     "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.4.14", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.14", "@biomejs/cli-darwin-x64": "2.4.14", "@biomejs/cli-linux-arm64": "2.4.14", "@biomejs/cli-linux-arm64-musl": "2.4.14", "@biomejs/cli-linux-x64": "2.4.14", "@biomejs/cli-linux-x64-musl": "2.4.14", "@biomejs/cli-win32-arm64": "2.4.14", "@biomejs/cli-win32-x64": "2.4.14" }, "bin": { "biome": "bin/biome" } }, "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.14", "", { "os": "linux", "cpu": "x64" }, "sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.14", "", { "os": "linux", "cpu": "x64" }, "sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.14", "", { "os": "win32", "cpu": "x64" }, "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA=="],
 
     "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -159,7 +159,10 @@ Trust ladder: T0 read/preview, T2 emit (requires `--yes`), T3 void (requires
 
 Idempotency: every emit is keyed by `RUC-tipo-serie-numero`. Re-running with the
 same key returns the cached CDR without re-submitting to SUNAT. Audit log lives
-in `~/.sunat/audit/YYYY-MM-DD.jsonl` (two-phase: pending → success/error).
+in `~/.sunat/audit/YYYY-MM.jsonl` (two-phase: pending → success/error). Older
+months can be compacted into `~/.sunat/audit/archive/YYYY-MM.jsonl.gz` with
+`sunat-cli audit compact`, and archived months can be removed manually with
+`sunat-cli audit prune --before YYYY-MM`.
 
 Full shaping rationale + recon dossier + SUNAT debugging notes:
 `src/commands/cpe/RESEARCH.md`.

--- a/packages/cli/bin/sunat.ts
+++ b/packages/cli/bin/sunat.ts
@@ -1,16 +1,17 @@
 #!/usr/bin/env bun
 import { Command } from "commander";
-import { createRheCommand } from "../src/commands/rhe/index.ts";
+import { createApiCommand } from "../src/commands/api/index.ts";
+import { createAuditCommand } from "../src/commands/audit.ts";
+import { createCpeCommand } from "../src/commands/cpe/index.ts";
 import { createF616Command } from "../src/commands/f616/index.ts";
 import { createLoginCommand } from "../src/commands/login.ts";
-import { createWhoamiCommand } from "../src/commands/whoami.ts";
-import { createSchemaCommand } from "../src/commands/schema.ts";
-import { createApiCommand } from "../src/commands/api/index.ts";
 import { createLukeaCommand } from "../src/commands/lukea/index.ts";
-import { createCpeCommand } from "../src/commands/cpe/index.ts";
 import { createPadronCommand } from "../src/commands/padron/index.ts";
+import { createRheCommand } from "../src/commands/rhe/index.ts";
+import { createSchemaCommand } from "../src/commands/schema.ts";
 import { createSireCommand } from "../src/commands/sire/index.ts";
 import { createTipoCambioCommand } from "../src/commands/tipo-cambio.ts";
+import { createWhoamiCommand } from "../src/commands/whoami.ts";
 
 const program = new Command();
 
@@ -37,5 +38,6 @@ program.addCommand(createCpeCommand());
 program.addCommand(createPadronCommand());
 program.addCommand(createSireCommand());
 program.addCommand(createTipoCambioCommand());
+program.addCommand(createAuditCommand());
 
 program.parse();

--- a/packages/cli/biome.json
+++ b/packages/cli/biome.json
@@ -1,6 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
-	"organizeImports": { "enabled": true },
+	"$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
 	"linter": { "enabled": true, "rules": { "recommended": true } },
 	"formatter": { "enabled": true, "indentStyle": "tab", "lineWidth": 120 }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,6 +48,7 @@
 		"yazl": "^3.3.1"
 	},
 	"devDependencies": {
+		"@biomejs/biome": "^2.4.14",
 		"@types/bun": "latest",
 		"@types/node-forge": "^1.3.14",
 		"@types/yauzl": "^2.10.3",

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -1,0 +1,115 @@
+import { Command } from "commander";
+import {
+	archivedAuditRecoveryPath,
+	compactAuditLogs,
+	DEFAULT_AUTO_COMPACT_AFTER_MONTHS,
+	DEFAULT_RECOMMENDED_ARCHIVE_MONTHS,
+	listArchivedAuditMonths,
+	pruneArchivedAuditLogs,
+} from "../data/audit.ts";
+import { output, outputError } from "../utils/output.ts";
+
+type Format = "json" | "table" | "auto";
+
+function getFormat(cmd: Command): Format {
+	let parent: Command | null = cmd;
+	while (parent) {
+		const opts = parent.opts();
+		if (opts.output) return opts.output as Format;
+		parent = parent.parent;
+	}
+	return "auto";
+}
+
+function parseMonths(value: string): number {
+	const months = Number(value);
+	if (!Number.isInteger(months) || months < 0)
+		throw new Error(`Invalid months: "${value}". Expected a non-negative integer`);
+	return months;
+}
+
+export function createAuditCommand(): Command {
+	const audit = new Command("audit").description("Manage local audit log rotation and archives.");
+
+	audit
+		.command("compact")
+		.description("Compress active audit months older than the retention window into ~/.sunat/audit/archive.")
+		.option(
+			"--older-than-months <n>",
+			`Compact months with age >= n. Default: ${DEFAULT_AUTO_COMPACT_AFTER_MONTHS}`,
+			String(DEFAULT_AUTO_COMPACT_AFTER_MONTHS),
+		)
+		.action((opts, cmd) => {
+			const format = getFormat(cmd);
+			try {
+				const olderThanMonths = parseMonths(opts.olderThanMonths);
+				const result = compactAuditLogs({ olderThanMonths });
+				const archivedMonths = listArchivedAuditMonths();
+				const json = {
+					success: true,
+					policy: {
+						autoCompactAfterMonths: DEFAULT_AUTO_COMPACT_AFTER_MONTHS,
+						recommendedArchiveMonths: DEFAULT_RECOMMENDED_ARCHIVE_MONTHS,
+						autoDelete: false,
+					},
+					compactedMonths: result.compactedMonths,
+					compactedFiles: result.compactedFiles,
+					archivePaths: result.archivePaths,
+					skippedMonths: result.skippedMonths,
+					archivedMonths,
+					recovery: result.compactedMonths.map((month) => ({
+						month,
+						archivePath: archivedAuditRecoveryPath(month),
+						command: `gunzip -c ${archivedAuditRecoveryPath(month)} > ~/.sunat/audit/${month}.jsonl`,
+					})),
+				};
+				output(format, {
+					json,
+					table: {
+						headers: ["Month", "Archive", "Recovery"],
+						rows:
+							result.compactedMonths.length > 0
+								? result.compactedMonths.map((month) => [
+										month,
+										archivedAuditRecoveryPath(month),
+										`gunzip -c .../${month}.jsonl.gz > ~/.sunat/audit/${month}.jsonl`,
+									])
+								: [["-", "-", "no months compacted"]],
+					},
+				});
+			} catch (err) {
+				outputError(err instanceof Error ? err.message : String(err), format);
+			}
+		});
+
+	audit
+		.command("prune")
+		.description("Delete archived audit months before a cutoff. This never runs automatically.")
+		.requiredOption("--before <YYYY-MM>", "Delete archived months strictly before this month")
+		.action((opts, cmd) => {
+			const format = getFormat(cmd);
+			try {
+				const result = pruneArchivedAuditLogs(opts.before);
+				output(format, {
+					json: {
+						success: true,
+						before: opts.before,
+						prunedMonths: result.prunedMonths,
+						prunedPaths: result.prunedPaths,
+						autoDelete: false,
+					},
+					table: {
+						headers: ["Month", "Archive"],
+						rows:
+							result.prunedMonths.length > 0
+								? result.prunedMonths.map((month, i) => [month, result.prunedPaths[i]])
+								: [["-", "no archived months pruned"]],
+					},
+				});
+			} catch (err) {
+				outputError(err instanceof Error ? err.message : String(err), format);
+			}
+		});
+
+	return audit;
+}

--- a/packages/cli/src/cpe/idempotency.ts
+++ b/packages/cli/src/cpe/idempotency.ts
@@ -13,10 +13,7 @@
  * operator can investigate (likely a crash mid-submit).
  */
 
-import { existsSync, readFileSync, readdirSync } from "fs";
-import { join } from "path";
-import { audit } from "../data/audit.ts";
-import { paths } from "../data/config.ts";
+import { audit, iterateActiveAuditEntries } from "../data/audit.ts";
 import type { CpeResult } from "./drivers/types.ts";
 
 export type CpeTipo = "01" | "03" | "07" | "08" | "09";
@@ -84,7 +81,12 @@ export function logPending(key: IdempotencyKey, command: string, args: Record<st
 	});
 }
 
-export function logSuccess(key: IdempotencyKey, command: string, args: Record<string, unknown>, result: CpeResult): void {
+export function logSuccess(
+	key: IdempotencyKey,
+	command: string,
+	args: Record<string, unknown>,
+	result: CpeResult,
+): void {
 	audit({
 		command,
 		args,
@@ -110,19 +112,5 @@ export function logFailure(key: IdempotencyKey, command: string, args: Record<st
 }
 
 function* iterateAudit(): Generator<AuditEntry> {
-	const dir = paths.auditDir;
-	if (!existsSync(dir)) return;
-	const files = readdirSync(dir).filter((f) => f.endsWith(".jsonl")).sort();
-	for (const file of files) {
-		const path = join(dir, file);
-		const content = readFileSync(path, "utf-8");
-		for (const line of content.split("\n")) {
-			if (!line.trim()) continue;
-			try {
-				yield JSON.parse(line) as AuditEntry;
-			} catch {
-				// skip malformed line
-			}
-		}
-	}
+	yield* iterateActiveAuditEntries();
 }

--- a/packages/cli/src/data/audit.ts
+++ b/packages/cli/src/data/audit.ts
@@ -1,8 +1,9 @@
-import { appendFileSync, mkdirSync, existsSync } from "fs";
+import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
+import { gunzipSync, gzipSync } from "zlib";
 import { paths } from "./config.ts";
 
-interface AuditEntry {
+export interface AuditEntry {
 	timestamp: string;
 	command: string;
 	args: Record<string, unknown>;
@@ -12,21 +13,204 @@ interface AuditEntry {
 	durationMs?: number;
 }
 
-export function audit(entry: Omit<AuditEntry, "timestamp">): void {
-	const dir = paths.auditDir;
+export interface AuditCompactResult {
+	compactedMonths: string[];
+	compactedFiles: string[];
+	archivePaths: string[];
+	skippedMonths: string[];
+}
+
+export interface AuditPruneResult {
+	prunedMonths: string[];
+	prunedPaths: string[];
+}
+
+const MONTHLY_AUDIT_FILE = /^(\d{4}-\d{2})\.jsonl$/;
+const LEGACY_DAILY_AUDIT_FILE = /^(\d{4}-\d{2})-\d{2}\.jsonl$/;
+const ARCHIVED_AUDIT_FILE = /^(\d{4}-\d{2})\.jsonl\.gz$/;
+
+export const DEFAULT_AUTO_COMPACT_AFTER_MONTHS = 6;
+export const DEFAULT_RECOMMENDED_ARCHIVE_MONTHS = 24;
+
+function ensureAuditDir(): void {
+	if (!existsSync(paths.auditDir)) mkdirSync(paths.auditDir, { recursive: true });
+}
+
+function ensureAuditArchiveDir(): string {
+	const dir = join(paths.auditDir, "archive");
 	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+	return dir;
+}
 
-	const today = new Date().toISOString().split("T")[0];
-	const file = join(dir, `${today}.jsonl`);
+function monthKey(date: Date): string {
+	return date.toISOString().slice(0, 7);
+}
+
+function parseMonth(month: string): { year: number; month: number } {
+	const match = /^(\d{4})-(\d{2})$/.exec(month);
+	if (!match) throw new Error(`Invalid month: "${month}". Expected YYYY-MM`);
+	const year = Number(match[1]);
+	const monthNumber = Number(match[2]);
+	if (monthNumber < 1 || monthNumber > 12) throw new Error(`Invalid month: "${month}". Expected YYYY-MM`);
+	return { year, month: monthNumber };
+}
+
+function monthDiff(currentMonth: string, candidateMonth: string): number {
+	const current = parseMonth(currentMonth);
+	const candidate = parseMonth(candidateMonth);
+	return (current.year - candidate.year) * 12 + (current.month - candidate.month);
+}
+
+function auditFileNameForDate(date: Date): string {
+	return `${monthKey(date)}.jsonl`;
+}
+
+function auditArchivePath(month: string): string {
+	return join(ensureAuditArchiveDir(), `${month}.jsonl.gz`);
+}
+
+function readArchive(month: string): string {
+	const archivePath = auditArchivePath(month);
+	if (!existsSync(archivePath)) return "";
+	return gunzipSync(readFileSync(archivePath)).toString("utf-8");
+}
+
+function readAuditFile(path: string): string {
+	return existsSync(path) ? readFileSync(path, "utf-8") : "";
+}
+
+function listAuditDirFiles(): string[] {
+	ensureAuditDir();
+	return readdirSync(paths.auditDir).sort();
+}
+
+function resolveMonthFromFile(file: string): string | null {
+	const monthly = MONTHLY_AUDIT_FILE.exec(file);
+	if (monthly) return monthly[1];
+	const legacy = LEGACY_DAILY_AUDIT_FILE.exec(file);
+	if (legacy) return legacy[1];
+	return null;
+}
+
+export function listActiveAuditFiles(): string[] {
+	return listAuditDirFiles().filter((file) => resolveMonthFromFile(file) !== null);
+}
+
+export function listArchivedAuditMonths(): string[] {
+	const archiveDir = ensureAuditArchiveDir();
+	return readdirSync(archiveDir)
+		.map((file) => ARCHIVED_AUDIT_FILE.exec(file)?.[1] || null)
+		.filter((month): month is string => month !== null)
+		.sort();
+}
+
+export function archivedAuditRecoveryPath(month: string): string {
+	return auditArchivePath(month);
+}
+
+let autoCompacted = false;
+
+function maybeAutoCompact(): void {
+	if (autoCompacted) return;
+	autoCompacted = true;
+	compactAuditLogs({ olderThanMonths: DEFAULT_AUTO_COMPACT_AFTER_MONTHS });
+}
+
+export function audit(entry: Omit<AuditEntry, "timestamp">): void {
+	ensureAuditDir();
+	maybeAutoCompact();
+	const file = join(paths.auditDir, auditFileNameForDate(new Date()));
 	const full: AuditEntry = { timestamp: new Date().toISOString(), ...entry };
-
 	appendFileSync(file, JSON.stringify(full) + "\n");
 }
 
 export function auditScreenshotPath(operation: string): string {
 	const dir = join(paths.auditDir, "screenshots");
 	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-
 	const ts = new Date().toISOString().replace(/[:.]/g, "-");
 	return join(dir, `${operation}-${ts}.png`);
+}
+
+export function* iterateActiveAuditEntries(): Generator<AuditEntry> {
+	maybeAutoCompact();
+	for (const file of listActiveAuditFiles()) {
+		const path = join(paths.auditDir, file);
+		const content = readAuditFile(path);
+		for (const line of content.split("\n")) {
+			if (!line.trim()) continue;
+			try {
+				yield JSON.parse(line) as AuditEntry;
+			} catch {}
+		}
+	}
+}
+
+export function compactAuditLogs(options: { olderThanMonths?: number; now?: Date } = {}): AuditCompactResult {
+	ensureAuditDir();
+	const olderThanMonths = options.olderThanMonths ?? DEFAULT_AUTO_COMPACT_AFTER_MONTHS;
+	const nowMonth = monthKey(options.now ?? new Date());
+	const filesByMonth = new Map<string, string[]>();
+
+	for (const file of listActiveAuditFiles()) {
+		const month = resolveMonthFromFile(file);
+		if (!month) continue;
+		const bucket = filesByMonth.get(month) || [];
+		bucket.push(file);
+		filesByMonth.set(month, bucket);
+	}
+
+	const compactedMonths: string[] = [];
+	const compactedFiles: string[] = [];
+	const archivePaths: string[] = [];
+	const skippedMonths: string[] = [];
+
+	for (const [month, files] of [...filesByMonth.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+		if (monthDiff(nowMonth, month) < olderThanMonths) {
+			skippedMonths.push(month);
+			continue;
+		}
+
+		const merged = [readArchive(month), ...files.map((file) => readAuditFile(join(paths.auditDir, file)))]
+			.filter((chunk) => chunk.trim().length > 0)
+			.join("")
+			.replace(/\n*$/, "\n");
+
+		if (!merged.trim()) {
+			for (const file of files) rmSync(join(paths.auditDir, file), { force: true });
+			compactedMonths.push(month);
+			compactedFiles.push(...files.map((file) => join(paths.auditDir, file)));
+			archivePaths.push(auditArchivePath(month));
+			continue;
+		}
+
+		const archivePath = auditArchivePath(month);
+		writeFileSync(archivePath, gzipSync(merged));
+		for (const file of files) rmSync(join(paths.auditDir, file), { force: true });
+
+		compactedMonths.push(month);
+		compactedFiles.push(...files.map((file) => join(paths.auditDir, file)));
+		archivePaths.push(archivePath);
+	}
+
+	return { compactedMonths, compactedFiles, archivePaths, skippedMonths };
+}
+
+export function pruneArchivedAuditLogs(beforeMonth: string): AuditPruneResult {
+	parseMonth(beforeMonth);
+	const prunedMonths: string[] = [];
+	const prunedPaths: string[] = [];
+	const archiveDir = ensureAuditArchiveDir();
+
+	for (const file of readdirSync(archiveDir).sort()) {
+		const match = ARCHIVED_AUDIT_FILE.exec(file);
+		if (!match) continue;
+		const month = match[1];
+		if (month >= beforeMonth) continue;
+		const path = join(archiveDir, file);
+		rmSync(path, { force: true });
+		prunedMonths.push(month);
+		prunedPaths.push(path);
+	}
+
+	return { prunedMonths, prunedPaths };
 }

--- a/packages/cli/tests/e2e/audit-cli.test.ts
+++ b/packages/cli/tests/e2e/audit-cli.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { gunzipSync, gzipSync } from "zlib";
+
+const CLI = join(import.meta.dir, "..", "..", "bin", "sunat.ts");
+const tempHomes: string[] = [];
+
+interface CliResult {
+	stdout: string;
+	stderr: string;
+	exitCode: number;
+}
+
+function createTempHome(): string {
+	const home = mkdtempSync(join(tmpdir(), "sunat-audit-test-"));
+	tempHomes.push(home);
+	mkdirSync(join(home, ".sunat", "audit"), { recursive: true });
+	return home;
+}
+
+async function runCli(args: string[], home: string): Promise<CliResult> {
+	const proc = Bun.spawn(["bun", "run", CLI, ...args], {
+		stdout: "pipe",
+		stderr: "pipe",
+		env: { ...process.env, HOME: home, CPE_DRIVER: "mock" },
+	});
+	const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+	const exitCode = await proc.exited;
+	return { stdout, stderr, exitCode };
+}
+
+afterEach(() => {
+	for (const home of tempHomes.splice(0)) {
+		rmSync(home, { recursive: true, force: true });
+	}
+});
+
+describe("sunat audit — E2E", () => {
+	test("audit compact archives old active months and keeps recent monthly logs active", async () => {
+		const home = createTempHome();
+		const auditDir = join(home, ".sunat", "audit");
+		const currentMonth = new Date().toISOString().slice(0, 7);
+
+		writeFileSync(join(auditDir, "2000-01.jsonl"), '{"entry":"monthly-old"}\n');
+		writeFileSync(join(auditDir, "2000-01-15.jsonl"), '{"entry":"legacy-daily-old"}\n');
+		writeFileSync(join(auditDir, `${currentMonth}.jsonl`), '{"entry":"current"}\n');
+
+		const result = await runCli(["-o", "json", "audit", "compact"], home);
+		expect(result.exitCode).toBe(0);
+
+		const json = JSON.parse(result.stdout) as { compactedMonths: string[]; archivePaths: string[] };
+		expect(json.compactedMonths).toContain("2000-01");
+		expect(existsSync(join(auditDir, "2000-01.jsonl"))).toBe(false);
+		expect(existsSync(join(auditDir, "2000-01-15.jsonl"))).toBe(false);
+		expect(existsSync(join(auditDir, `${currentMonth}.jsonl`))).toBe(true);
+		expect(json.archivePaths).toContain(join(auditDir, "archive", "2000-01.jsonl.gz"));
+
+		const archived = gunzipSync(readFileSync(join(auditDir, "archive", "2000-01.jsonl.gz"))).toString("utf-8");
+		expect(archived).toContain("monthly-old");
+		expect(archived).toContain("legacy-daily-old");
+	});
+
+	test("audit prune deletes archived months strictly before the cutoff", async () => {
+		const home = createTempHome();
+		const archiveDir = join(home, ".sunat", "audit", "archive");
+		mkdirSync(archiveDir, { recursive: true });
+
+		writeFileSync(join(archiveDir, "2000-01.jsonl.gz"), gzipSync('{"entry":"old"}\n'));
+		writeFileSync(join(archiveDir, "2001-02.jsonl.gz"), gzipSync('{"entry":"keep"}\n'));
+
+		const result = await runCli(["-o", "json", "audit", "prune", "--before", "2001-02"], home);
+		expect(result.exitCode).toBe(0);
+
+		const json = JSON.parse(result.stdout) as { prunedMonths: string[] };
+		expect(json.prunedMonths).toEqual(["2000-01"]);
+		expect(existsSync(join(archiveDir, "2000-01.jsonl.gz"))).toBe(false);
+		expect(existsSync(join(archiveDir, "2001-02.jsonl.gz"))).toBe(true);
+	});
+});

--- a/packages/cli/tests/unit/idempotency.test.ts
+++ b/packages/cli/tests/unit/idempotency.test.ts
@@ -12,12 +12,12 @@ import { paths } from "../../src/data/config.ts";
 
 const TEST_RUC = "29999999999";
 const TEST_TAG = "TEST_IDEMPOTENCY";
-const today = () => new Date().toISOString().split("T")[0];
+const currentMonth = () => new Date().toISOString().slice(0, 7);
 let auditFile: string;
 
 beforeAll(() => {
 	mkdirSync(paths.auditDir, { recursive: true });
-	auditFile = join(paths.auditDir, `${today()}.jsonl`);
+	auditFile = join(paths.auditDir, `${currentMonth()}.jsonl`);
 });
 
 afterAll(() => {


### PR DESCRIPTION
## Summary
- rotate audit writes to monthly JSONL files and auto-compact older active months into gzip archives
- add `sunat audit compact` and `sunat audit prune --before YYYY-MM` with recovery paths for archived months
- keep `cpe doctor stale_pendings` and idempotency reads on active logs only, plus add coverage for compaction/prune flows

## Validation
- `bun run test` ✅
- `bun run check` still fails on pre-existing repo-wide Biome diagnostics outside this issue after the command became runnable in this workspace

Closes #20