### PR TITLE
[P3] Multi-RUC profile testing + multi-emisor support

### DIFF
--- a/packages/cli/LIMITATIONS.md
+++ b/packages/cli/LIMITATIONS.md
@@ -125,7 +125,7 @@ These predate the agent-first refactor and use the older agent-browser scraping 
 
 - **Production submissions** never tested. Always use `--mode beta` (or its equivalent) until you've manually verified one production emission.
 - **Stress / rate-limit tests** never run. SUNAT WAF behavior under load is unknown.
-- **Multi-RUC** — config file supports profiles, but never tested with multiple active RUCs in the same process.
+- **Live Multi-RUC SUNAT submissions** — profile switching is covered by local E2E tests, but real SUNAT beta/prod runs across multiple RUCs still need manual QA.
 - **Cert expiry** — `cpe doctor` warns at <30 days. Never tested with an actually-expired cert.
 
 ### Environment

--- a/packages/cli/LIMITATIONS.md
+++ b/packages/cli/LIMITATIONS.md
@@ -124,7 +124,7 @@ These predate the agent-first refactor and use the older agent-browser scraping 
 
 - **Production submissions** never tested. Always use `--mode beta` (or its equivalent) until you've manually verified one production emission.
 - **Stress / rate-limit tests** never run. SUNAT WAF behavior under load is unknown.
-- **Multi-RUC** — config file supports profiles, but never tested with multiple active RUCs in the same process.
+- **Live Multi-RUC SUNAT submissions** — profile switching is covered by local E2E tests, but real SUNAT beta/prod runs across multiple RUCs still need manual QA.
 - **Cert expiry** — `cpe doctor` warns at <30 days. Never tested with an actually-expired cert.
 
 ### Environment

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -1,10 +1,12 @@
 import { Command } from "commander";
 import {
 	archivedAuditRecoveryPath,
+	auditEntryRuc,
 	compactAuditLogs,
 	DEFAULT_AUTO_COMPACT_AFTER_MONTHS,
 	DEFAULT_RECOMMENDED_ARCHIVE_MONTHS,
 	listArchivedAuditMonths,
+	listAuditEntries,
 	pruneArchivedAuditLogs,
 } from "../data/audit.ts";
 import { output, outputError } from "../utils/output.ts";
@@ -28,8 +30,45 @@ function parseMonths(value: string): number {
 	return months;
 }
 
+function parseLimit(value: string): number {
+	const limit = Number(value);
+	if (!Number.isInteger(limit) || limit < 1) throw new Error(`Invalid limit: "${value}". Expected a positive integer`);
+	return limit;
+}
+
 export function createAuditCommand(): Command {
 	const audit = new Command("audit").description("Manage local audit log rotation and archives.");
+
+	audit
+		.command("list")
+		.description("List active audit entries.")
+		.option("--ruc <ruc>", "Filter by emisor RUC")
+		.option("--limit <n>", "Maximum entries to return", "50")
+		.action((opts, cmd) => {
+			const format = getFormat(cmd);
+			try {
+				const limit = parseLimit(opts.limit);
+				const entries = listAuditEntries({ ruc: opts.ruc, limit });
+				output(format, {
+					json: { entries, count: entries.length, ruc: opts.ruc || null },
+					table: {
+						headers: ["Timestamp", "RUC", "Command", "Result", "ID"],
+						rows:
+							entries.length > 0
+								? entries.map((entry) => [
+										entry.timestamp,
+										auditEntryRuc(entry) || "-",
+										entry.command,
+										entry.result,
+										typeof entry.details?.id === "string" ? entry.details.id : "-",
+									])
+								: [["-", opts.ruc || "-", "-", "-", "no audit entries"]],
+					},
+				});
+			} catch (err) {
+				outputError(err instanceof Error ? err.message : String(err), format);
+			}
+		});
 
 	audit
 		.command("compact")

--- a/packages/cli/src/commands/cpe/index.ts
+++ b/packages/cli/src/commands/cpe/index.ts
@@ -1,15 +1,24 @@
 import { Command } from "commander";
 import { audit } from "../../data/audit.ts";
 import { clearQueueForEmisor, enqueueBoleta, listQueueDates, readQueue } from "../../cpe/boleta-queue.ts";
-import { resolveCpeContext } from "../../cpe/config.ts";
+import { loadCpeConfig, resolveCpeAuditContext, resolveCpeContext, saveCpeConfig } from "../../cpe/config.ts";
 import { getDriver } from "../../cpe/drivers/index.ts";
 import type { CpeDriverName } from "../../cpe/drivers/types.ts";
 import { parseFacturaInput, parseNotaInput } from "../../cpe/parsers.ts";
-import { loadCpeConfig, saveCpeConfig } from "../../cpe/config.ts";
 import { boletaRequiresIndividualSubmission } from "../../cpe/ubl/boleta.ts";
 import { output, outputError } from "../../utils/output.ts";
 
 type Format = "json" | "table" | "auto";
+
+function mockAuditDetails(
+	tipo: "01" | "03" | "07" | "08",
+	input: { serie: string; numero: number },
+	result: Record<string, unknown>,
+): Record<string, unknown> {
+	const context = resolveCpeAuditContext();
+	const id = context.emisorRuc ? `${context.emisorRuc}-${tipo}-${input.serie}-${input.numero}` : result.id;
+	return { ...result, id, ...context };
+}
 
 function getFormat(cmd: Command): Format {
 	let parent: Command | null = cmd;
@@ -131,7 +140,7 @@ export function createCpeCommand(): Command {
 						command: "cpe factura emit",
 						args: input as unknown as Record<string, unknown>,
 						result: "success",
-						details: result as unknown as Record<string, unknown>,
+						details: mockAuditDetails("01", input, result as unknown as Record<string, unknown>),
 					});
 				}
 				output(format, { json: { success: true, ...result } });
@@ -206,7 +215,12 @@ export function createCpeCommand(): Command {
 
 				const result = await driver.emitBoleta(input);
 				if (driver.info().name === "mock") {
-					audit({ command: "cpe boleta emit", args: input as unknown as Record<string, unknown>, result: "success", details: result as unknown as Record<string, unknown> });
+					audit({
+						command: "cpe boleta emit",
+						args: input as unknown as Record<string, unknown>,
+						result: "success",
+						details: mockAuditDetails("03", input, result as unknown as Record<string, unknown>),
+					});
 				}
 				output(format, { json: { success: true, ...result } });
 			} catch (err) {
@@ -297,7 +311,15 @@ export function createCpeCommand(): Command {
 				}
 
 				const result = await driver.emitNotaCredito(input);
-				audit({ command: "cpe nc emit", args: input as unknown as Record<string, unknown>, result: "success", details: result as unknown as Record<string, unknown> });
+				audit({
+					command: "cpe nc emit",
+					args: input as unknown as Record<string, unknown>,
+					result: "success",
+					details:
+						driver.info().name === "mock"
+							? mockAuditDetails("07", input, result as unknown as Record<string, unknown>)
+							: (result as unknown as Record<string, unknown>),
+				});
 				output(format, { json: { success: true, ...result } });
 			} catch (err) {
 				outputError(err instanceof Error ? err.message : String(err), format);
@@ -333,7 +355,10 @@ export function createCpeCommand(): Command {
 					command: "cpe nd emit",
 					args: input as unknown as Record<string, unknown>,
 					result: "success",
-					details: result as unknown as Record<string, unknown>,
+					details:
+						driver.info().name === "mock"
+							? mockAuditDetails("08", input, result as unknown as Record<string, unknown>)
+							: (result as unknown as Record<string, unknown>),
 				});
 				output(format, { json: { success: true, ...result } });
 			} catch (err) {
@@ -879,6 +904,32 @@ export function createCpeCommand(): Command {
 			try {
 				const config = loadCpeConfig();
 				output(format, { json: { defaultProfile: config.defaultProfile || null, profiles: config.profiles } });
+			} catch (err) {
+				outputError(err instanceof Error ? err.message : String(err), format);
+			}
+		});
+
+	profile
+		.command("use")
+		.description("Set the active CPE profile")
+		.argument("<name>", "Profile name")
+		.action((name, _opts, cmd) => {
+			const format = getFormat(cmd);
+			try {
+				const config = loadCpeConfig();
+				if (!config.profiles[name]) {
+					outputError(`CPE profile "${name}" not found. Run: sunat cpe profile list`, format);
+					return;
+				}
+				config.defaultProfile = name;
+				saveCpeConfig(config);
+				output(format, {
+					json: {
+						ok: true,
+						activeProfile: name,
+						emisorRuc: config.profiles[name].emisor.ruc,
+					},
+				});
 			} catch (err) {
 				outputError(err instanceof Error ? err.message : String(err), format);
 			}

--- a/packages/cli/src/commands/cpe/index.ts
+++ b/packages/cli/src/commands/cpe/index.ts
@@ -2,16 +2,25 @@ import { Command } from "commander";
 import { audit } from "../../data/audit.ts";
 import { clearQueueForEmisor, enqueueBoleta, listQueueDates, readQueue } from "../../cpe/boleta-queue.ts";
 import { buildCatalogCoverageReport, hasCatalogWarnings } from "../../cpe/catalogos/index.ts";
-import { resolveCpeContext } from "../../cpe/config.ts";
+import { loadCpeConfig, resolveCpeAuditContext, resolveCpeContext, saveCpeConfig } from "../../cpe/config.ts";
 import { getDriver } from "../../cpe/drivers/index.ts";
 import type { CpeDriverName } from "../../cpe/drivers/types.ts";
 import { parseFacturaInput, parseNotaInput } from "../../cpe/parsers.ts";
-import { loadCpeConfig, saveCpeConfig } from "../../cpe/config.ts";
 import { boletaRequiresIndividualSubmission } from "../../cpe/ubl/boleta.ts";
 import { resolveSecret } from "../../data/keychain.ts";
 import { output, outputError } from "../../utils/output.ts";
 
 type Format = "json" | "table" | "auto";
+
+function mockAuditDetails(
+	tipo: "01" | "03" | "07" | "08",
+	input: { serie: string; numero: number },
+	result: Record<string, unknown>,
+): Record<string, unknown> {
+	const context = resolveCpeAuditContext();
+	const id = context.emisorRuc ? `${context.emisorRuc}-${tipo}-${input.serie}-${input.numero}` : result.id;
+	return { ...result, id, ...context };
+}
 
 function getFormat(cmd: Command): Format {
 	let parent: Command | null = cmd;
@@ -137,7 +146,7 @@ export function createCpeCommand(): Command {
 						command: "cpe factura emit",
 						args: input as unknown as Record<string, unknown>,
 						result: "success",
-						details: result as unknown as Record<string, unknown>,
+						details: mockAuditDetails("01", input, result as unknown as Record<string, unknown>),
 					});
 				}
 				output(format, { json: { success: true, ...result } });
@@ -212,7 +221,12 @@ export function createCpeCommand(): Command {
 
 				const result = await driver.emitBoleta(input);
 				if (driver.info().name === "mock") {
-					audit({ command: "cpe boleta emit", args: input as unknown as Record<string, unknown>, result: "success", details: result as unknown as Record<string, unknown> });
+					audit({
+						command: "cpe boleta emit",
+						args: input as unknown as Record<string, unknown>,
+						result: "success",
+						details: mockAuditDetails("03", input, result as unknown as Record<string, unknown>),
+					});
 				}
 				output(format, { json: { success: true, ...result } });
 			} catch (err) {
@@ -303,7 +317,15 @@ export function createCpeCommand(): Command {
 				}
 
 				const result = await driver.emitNotaCredito(input);
-				audit({ command: "cpe nc emit", args: input as unknown as Record<string, unknown>, result: "success", details: result as unknown as Record<string, unknown> });
+				audit({
+					command: "cpe nc emit",
+					args: input as unknown as Record<string, unknown>,
+					result: "success",
+					details:
+						driver.info().name === "mock"
+							? mockAuditDetails("07", input, result as unknown as Record<string, unknown>)
+							: (result as unknown as Record<string, unknown>),
+				});
 				output(format, { json: { success: true, ...result } });
 			} catch (err) {
 				outputError(err instanceof Error ? err.message : String(err), format);
@@ -339,7 +361,10 @@ export function createCpeCommand(): Command {
 					command: "cpe nd emit",
 					args: input as unknown as Record<string, unknown>,
 					result: "success",
-					details: result as unknown as Record<string, unknown>,
+					details:
+						driver.info().name === "mock"
+							? mockAuditDetails("08", input, result as unknown as Record<string, unknown>)
+							: (result as unknown as Record<string, unknown>),
 				});
 				output(format, { json: { success: true, ...result } });
 			} catch (err) {
@@ -885,6 +910,32 @@ export function createCpeCommand(): Command {
 			try {
 				const config = loadCpeConfig();
 				output(format, { json: { defaultProfile: config.defaultProfile || null, profiles: config.profiles } });
+			} catch (err) {
+				outputError(err instanceof Error ? err.message : String(err), format);
+			}
+		});
+
+	profile
+		.command("use")
+		.description("Set the active CPE profile")
+		.argument("<name>", "Profile name")
+		.action((name, _opts, cmd) => {
+			const format = getFormat(cmd);
+			try {
+				const config = loadCpeConfig();
+				if (!config.profiles[name]) {
+					outputError(`CPE profile "${name}" not found. Run: sunat cpe profile list`, format);
+					return;
+				}
+				config.defaultProfile = name;
+				saveCpeConfig(config);
+				output(format, {
+					json: {
+						ok: true,
+						activeProfile: name,
+						emisorRuc: config.profiles[name].emisor.ruc,
+					},
+				});
 			} catch (err) {
 				outputError(err instanceof Error ? err.message : String(err), format);
 			}

--- a/packages/cli/src/cpe/config.ts
+++ b/packages/cli/src/cpe/config.ts
@@ -45,6 +45,25 @@ export function saveCpeConfig(config: CpeConfig): void {
 	writeFileSync(CPE_CONFIG_FILE, JSON.stringify(config, null, 2));
 }
 
+export interface CpeAuditContext {
+	profileName?: string;
+	emisorRuc?: string;
+}
+
+export function activeCpeProfileName(config: CpeConfig = loadCpeConfig(), profileName?: string): string | undefined {
+	return profileName || process.env.CPE_PROFILE || config.defaultProfile;
+}
+
+export function resolveCpeAuditContext(profileName?: string): CpeAuditContext {
+	const config = loadCpeConfig();
+	const name = activeCpeProfileName(config, profileName);
+	const profile = name ? config.profiles[name] : undefined;
+	return {
+		profileName: name,
+		emisorRuc: process.env.CPE_EMISOR_RUC || profile?.emisor.ruc,
+	};
+}
+
 export interface ResolvedCpeContext {
 	emisor: CpeEmisor;
 	mode: "beta" | "prod";
@@ -56,12 +75,13 @@ export interface ResolvedCpeContext {
 
 export function resolveCpeContext(profileName?: string): ResolvedCpeContext {
 	const config = loadCpeConfig();
-	const name = profileName || process.env.CPE_PROFILE || config.defaultProfile;
+	const name = activeCpeProfileName(config, profileName);
 	const profile = name ? config.profiles[name] : undefined;
 
 	const emisorRuc = process.env.CPE_EMISOR_RUC || profile?.emisor.ruc;
 	const emisorRznSocial = process.env.CPE_EMISOR_RAZON_SOCIAL || profile?.emisor.razonSocial;
-	if (!emisorRuc) throw new Error("Emisor RUC not configured. Set CPE_EMISOR_RUC env var or run 'sunat cpe profile set'.");
+	if (!emisorRuc)
+		throw new Error("Emisor RUC not configured. Set CPE_EMISOR_RUC env var or run 'sunat cpe profile set'.");
 	if (!emisorRznSocial) throw new Error("Emisor razonSocial not configured. Set CPE_EMISOR_RAZON_SOCIAL env var.");
 
 	const mode = (process.env.CPE_MODE || profile?.mode || "beta") as "beta" | "prod";

--- a/packages/cli/src/cpe/config.ts
+++ b/packages/cli/src/cpe/config.ts
@@ -46,6 +46,25 @@ export function saveCpeConfig(config: CpeConfig): void {
 	writeFileSync(CPE_CONFIG_FILE, JSON.stringify(config, null, 2));
 }
 
+export interface CpeAuditContext {
+	profileName?: string;
+	emisorRuc?: string;
+}
+
+export function activeCpeProfileName(config: CpeConfig = loadCpeConfig(), profileName?: string): string | undefined {
+	return profileName || process.env.CPE_PROFILE || config.defaultProfile;
+}
+
+export function resolveCpeAuditContext(profileName?: string): CpeAuditContext {
+	const config = loadCpeConfig();
+	const name = activeCpeProfileName(config, profileName);
+	const profile = name ? config.profiles[name] : undefined;
+	return {
+		profileName: name,
+		emisorRuc: process.env.CPE_EMISOR_RUC || profile?.emisor.ruc,
+	};
+}
+
 export interface ResolvedCpeContext {
 	emisor: CpeEmisor;
 	mode: "beta" | "prod";
@@ -57,12 +76,13 @@ export interface ResolvedCpeContext {
 
 export function resolveCpeContext(profileName?: string): ResolvedCpeContext {
 	const config = loadCpeConfig();
-	const name = profileName || process.env.CPE_PROFILE || config.defaultProfile;
+	const name = activeCpeProfileName(config, profileName);
 	const profile = name ? config.profiles[name] : undefined;
 
 	const emisorRuc = process.env.CPE_EMISOR_RUC || profile?.emisor.ruc;
 	const emisorRznSocial = process.env.CPE_EMISOR_RAZON_SOCIAL || profile?.emisor.razonSocial;
-	if (!emisorRuc) throw new Error("Emisor RUC not configured. Set CPE_EMISOR_RUC env var or run 'sunat cpe profile set'.");
+	if (!emisorRuc)
+		throw new Error("Emisor RUC not configured. Set CPE_EMISOR_RUC env var or run 'sunat cpe profile set'.");
 	if (!emisorRznSocial) throw new Error("Emisor razonSocial not configured. Set CPE_EMISOR_RAZON_SOCIAL env var.");
 
 	const mode = (process.env.CPE_MODE || profile?.mode || "beta") as "beta" | "prod";

--- a/packages/cli/src/cpe/idempotency.ts
+++ b/packages/cli/src/cpe/idempotency.ts
@@ -77,7 +77,7 @@ export function logPending(key: IdempotencyKey, command: string, args: Record<st
 		command,
 		args,
 		result: "pending",
-		details: { id: idempotencyKey(key), stage: "pre-submit" },
+		details: { id: idempotencyKey(key), emisorRuc: key.emisorRuc, stage: "pre-submit" },
 	});
 }
 
@@ -93,6 +93,7 @@ export function logSuccess(
 		result: "success",
 		details: {
 			id: idempotencyKey(key),
+			emisorRuc: key.emisorRuc,
 			hash: result.hash,
 			status: result.status,
 			cdrCode: result.cdrCode,
@@ -107,7 +108,7 @@ export function logFailure(key: IdempotencyKey, command: string, args: Record<st
 		command,
 		args,
 		result: "error",
-		details: { id: idempotencyKey(key), error },
+		details: { id: idempotencyKey(key), emisorRuc: key.emisorRuc, error },
 	});
 }
 

--- a/packages/cli/src/data/audit.ts
+++ b/packages/cli/src/data/audit.ts
@@ -25,6 +25,11 @@ export interface AuditPruneResult {
 	prunedPaths: string[];
 }
 
+export interface AuditListOptions {
+	ruc?: string;
+	limit?: number;
+}
+
 const MONTHLY_AUDIT_FILE = /^(\d{4}-\d{2})\.jsonl$/;
 const LEGACY_DAILY_AUDIT_FILE = /^(\d{4}-\d{2})-\d{2}\.jsonl$/;
 const ARCHIVED_AUDIT_FILE = /^(\d{4}-\d{2})\.jsonl\.gz$/;
@@ -143,6 +148,24 @@ export function* iterateActiveAuditEntries(): Generator<AuditEntry> {
 			} catch {}
 		}
 	}
+}
+
+export function listAuditEntries(options: AuditListOptions = {}): AuditEntry[] {
+	const entries = [...iterateActiveAuditEntries()];
+	const filtered = options.ruc ? entries.filter((entry) => auditEntryRuc(entry) === options.ruc) : entries;
+	const sorted = filtered.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+	return options.limit === undefined ? sorted : sorted.slice(0, options.limit);
+}
+
+export function auditEntryRuc(entry: AuditEntry): string | undefined {
+	const argsRuc = entry.args.emisorRuc;
+	if (typeof argsRuc === "string") return argsRuc;
+	const detailsRuc = entry.details?.emisorRuc;
+	if (typeof detailsRuc === "string") return detailsRuc;
+	const id = entry.details?.id;
+	if (typeof id !== "string") return undefined;
+	const match = /^(\d{11})-/.exec(id);
+	return match?.[1];
 }
 
 export function compactAuditLogs(options: { olderThanMonths?: number; now?: Date } = {}): AuditCompactResult {

--- a/packages/cli/tests/e2e/cpe-cli.test.ts
+++ b/packages/cli/tests/e2e/cpe-cli.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
 
 const CLI = join(import.meta.dir, "..", "..", "bin", "sunat.ts");
+const tempHomes: string[] = [];
 
 const validFactura = {
 	receptor: { tipoDoc: "6", numDoc: "20123456789", rznSocial: "ACME SAC" },
@@ -28,9 +31,32 @@ async function runCli(args: string[]): Promise<CliResult> {
 	return { stdout, stderr, exitCode };
 }
 
+async function runCliWithEnv(args: string[], env: Record<string, string | undefined>): Promise<CliResult> {
+	const proc = Bun.spawn(["bun", "run", CLI, ...args], {
+		stdout: "pipe",
+		stderr: "pipe",
+		env: { ...process.env, ...env },
+	});
+	const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+	const exitCode = await proc.exited;
+	return { stdout, stderr, exitCode };
+}
+
 function parseJson<T = unknown>(stdout: string): T {
 	return JSON.parse(stdout) as T;
 }
+
+function createTempHome(): string {
+	const home = mkdtempSync(join(tmpdir(), "sunat-cpe-test-"));
+	tempHomes.push(home);
+	return home;
+}
+
+afterEach(() => {
+	for (const home of tempHomes.splice(0)) {
+		rmSync(home, { recursive: true, force: true });
+	}
+});
 
 describe("sunat cpe — E2E", () => {
 	test("--help lists cpe namespace", async () => {
@@ -137,6 +163,65 @@ describe("sunat cpe — E2E", () => {
 		expect(json.cdrCode).toBe("0000");
 		expect(json.serie).toBe("F001");
 		expect(json.numero).toBe(1234);
+	});
+
+	test("emits facturas under two active profiles in one process and filters audit by RUC", async () => {
+		const home = createTempHome();
+		const script = `
+process.env.HOME = ${JSON.stringify(home)};
+process.env.CPE_DRIVER = "mock";
+delete process.env.CPE_PROFILE;
+delete process.env.CPE_EMISOR_RUC;
+const { createCpeCommand } = await import(${JSON.stringify(join(import.meta.dir, "..", "..", "src", "commands", "cpe", "index.ts"))});
+async function run(args) {
+	const command = createCpeCommand();
+	command.exitOverride();
+	await command.parseAsync(args, { from: "user" });
+}
+const base = ${JSON.stringify(validFactura)};
+await run(["profile", "set", "--name", "alpha", "--ruc", "20111111111", "--razon-social", "ALPHA SAC", "--mode", "beta"]);
+await run(["profile", "set", "--name", "beta", "--ruc", "20222222222", "--razon-social", "BETA SAC", "--mode", "beta"]);
+await run(["profile", "use", "alpha"]);
+await run(["factura", "emit", "--params", JSON.stringify({ ...base, serie: "F101", numero: 1 }), "--yes"]);
+await run(["profile", "use", "beta"]);
+await run(["factura", "emit", "--params", JSON.stringify({ ...base, serie: "F101", numero: 1 }), "--yes"]);
+`;
+		const proc = Bun.spawn(["bun", "--eval", script], {
+			stdout: "pipe",
+			stderr: "pipe",
+			env: { ...process.env, HOME: home, CPE_DRIVER: "mock" },
+		});
+		const [, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+		expect(await proc.exited).toBe(0);
+		expect(stderr).toBe("");
+
+		const month = new Date().toISOString().slice(0, 7);
+		const entries = readFileSync(join(home, ".sunat", "audit", `${month}.jsonl`), "utf-8")
+			.trim()
+			.split("\n")
+			.map(
+				(line) =>
+					JSON.parse(line) as { command: string; result: string; details?: { id?: string; emisorRuc?: string } },
+			)
+			.filter((entry) => entry.command === "cpe factura emit" && entry.result === "success");
+
+		expect(entries.map((entry) => entry.details?.emisorRuc).sort()).toEqual(["20111111111", "20222222222"]);
+		expect(entries.map((entry) => entry.details?.id).sort()).toEqual([
+			"20111111111-01-F101-1",
+			"20222222222-01-F101-1",
+		]);
+
+		const alphaAudit = await runCliWithEnv(["-o", "json", "audit", "list", "--ruc", "20111111111"], {
+			HOME: home,
+			CPE_DRIVER: "mock",
+		});
+		expect(alphaAudit.exitCode).toBe(0);
+		const alphaJson = parseJson<{ count: number; entries: Array<{ details?: { emisorRuc?: string; id?: string } }> }>(
+			alphaAudit.stdout,
+		);
+		expect(alphaJson.count).toBe(1);
+		expect(alphaJson.entries[0]?.details?.emisorRuc).toBe("20111111111");
+		expect(alphaJson.entries[0]?.details?.id).toBe("20111111111-01-F101-1");
 	});
 
 	test("cpe boleta emit --yes succeeds via mock", async () => {

--- a/packages/cli/tests/e2e/cpe-cli.test.ts
+++ b/packages/cli/tests/e2e/cpe-cli.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
 
 const CLI = join(import.meta.dir, "..", "..", "bin", "sunat.ts");
+const tempHomes: string[] = [];
 
 const validFactura = {
 	receptor: { tipoDoc: "6", numDoc: "20123456789", rznSocial: "ACME SAC" },
@@ -28,9 +31,32 @@ async function runCli(args: string[]): Promise<CliResult> {
 	return { stdout, stderr, exitCode };
 }
 
+async function runCliWithEnv(args: string[], env: Record<string, string | undefined>): Promise<CliResult> {
+	const proc = Bun.spawn(["bun", "run", CLI, ...args], {
+		stdout: "pipe",
+		stderr: "pipe",
+		env: { ...process.env, ...env },
+	});
+	const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+	const exitCode = await proc.exited;
+	return { stdout, stderr, exitCode };
+}
+
 function parseJson<T = unknown>(stdout: string): T {
 	return JSON.parse(stdout) as T;
 }
+
+function createTempHome(): string {
+	const home = mkdtempSync(join(tmpdir(), "sunat-cpe-test-"));
+	tempHomes.push(home);
+	return home;
+}
+
+afterEach(() => {
+	for (const home of tempHomes.splice(0)) {
+		rmSync(home, { recursive: true, force: true });
+	}
+});
 
 describe("sunat cpe — E2E", () => {
 	test("--help lists cpe namespace", async () => {
@@ -156,6 +182,65 @@ describe("sunat cpe — E2E", () => {
 		expect(json.cdrCode).toBe("0000");
 		expect(json.serie).toBe("F001");
 		expect(json.numero).toBe(1234);
+	});
+
+	test("emits facturas under two active profiles in one process and filters audit by RUC", async () => {
+		const home = createTempHome();
+		const script = `
+process.env.HOME = ${JSON.stringify(home)};
+process.env.CPE_DRIVER = "mock";
+delete process.env.CPE_PROFILE;
+delete process.env.CPE_EMISOR_RUC;
+const { createCpeCommand } = await import(${JSON.stringify(join(import.meta.dir, "..", "..", "src", "commands", "cpe", "index.ts"))});
+async function run(args) {
+	const command = createCpeCommand();
+	command.exitOverride();
+	await command.parseAsync(args, { from: "user" });
+}
+const base = ${JSON.stringify(validFactura)};
+await run(["profile", "set", "--name", "alpha", "--ruc", "20111111111", "--razon-social", "ALPHA SAC", "--mode", "beta"]);
+await run(["profile", "set", "--name", "beta", "--ruc", "20222222222", "--razon-social", "BETA SAC", "--mode", "beta"]);
+await run(["profile", "use", "alpha"]);
+await run(["factura", "emit", "--params", JSON.stringify({ ...base, serie: "F101", numero: 1 }), "--yes"]);
+await run(["profile", "use", "beta"]);
+await run(["factura", "emit", "--params", JSON.stringify({ ...base, serie: "F101", numero: 1 }), "--yes"]);
+`;
+		const proc = Bun.spawn(["bun", "--eval", script], {
+			stdout: "pipe",
+			stderr: "pipe",
+			env: { ...process.env, HOME: home, CPE_DRIVER: "mock" },
+		});
+		const [, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+		expect(await proc.exited).toBe(0);
+		expect(stderr).toBe("");
+
+		const month = new Date().toISOString().slice(0, 7);
+		const entries = readFileSync(join(home, ".sunat", "audit", `${month}.jsonl`), "utf-8")
+			.trim()
+			.split("\n")
+			.map(
+				(line) =>
+					JSON.parse(line) as { command: string; result: string; details?: { id?: string; emisorRuc?: string } },
+			)
+			.filter((entry) => entry.command === "cpe factura emit" && entry.result === "success");
+
+		expect(entries.map((entry) => entry.details?.emisorRuc).sort()).toEqual(["20111111111", "20222222222"]);
+		expect(entries.map((entry) => entry.details?.id).sort()).toEqual([
+			"20111111111-01-F101-1",
+			"20222222222-01-F101-1",
+		]);
+
+		const alphaAudit = await runCliWithEnv(["-o", "json", "audit", "list", "--ruc", "20111111111"], {
+			HOME: home,
+			CPE_DRIVER: "mock",
+		});
+		expect(alphaAudit.exitCode).toBe(0);
+		const alphaJson = parseJson<{ count: number; entries: Array<{ details?: { emisorRuc?: string; id?: string } }> }>(
+			alphaAudit.stdout,
+		);
+		expect(alphaJson.count).toBe(1);
+		expect(alphaJson.entries[0]?.details?.emisorRuc).toBe("20111111111");
+		expect(alphaJson.entries[0]?.details?.id).toBe("20111111111-01-F101-1");
 	});
 
 	test("cpe boleta emit --yes succeeds via mock", async () => {


### PR DESCRIPTION
Closes #22

## Summary
- add `sunat cpe profile use <name>` to persist the active CPE profile
- add `sunat audit list --ruc <ruc>` for emisor-scoped audit filtering
- stamp mock/idempotency audit entries with emisor RUC and add same-process multi-profile E2E coverage

## Verification
- `bun test packages/cli/tests/e2e/cpe-cli.test.ts`
- `bun run --cwd packages/cli test`
- `bun run --cwd packages/cli check` currently fails on pre-existing Biome diagnostics in unrelated files: `src/browser/cdp.ts`, `src/browser/client.ts`, and `src/commands/rhe/index.ts`