### PR TITLE
chore(release): publish to npm from main via OIDC, fix README command drift

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,104 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/cli/package.json"
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/cli
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Detect version change
+        id: version
+        run: |
+          LOCAL=$(jq -r .version package.json)
+          PUBLISHED=$(npm view @crafter/sunat-cli version 2>/dev/null || echo "0.0.0")
+          echo "local=$LOCAL" >> "$GITHUB_OUTPUT"
+          echo "published=$PUBLISHED" >> "$GITHUB_OUTPUT"
+          if [ "$LOCAL" != "$PUBLISHED" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Version changed: $PUBLISHED -> $LOCAL"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Version unchanged ($LOCAL), skipping publish"
+          fi
+
+      - name: Install dependencies
+        if: steps.version.outputs.changed == 'true'
+        run: bun install --frozen-lockfile
+        working-directory: .
+
+      - name: Unit tests
+        if: steps.version.outputs.changed == 'true'
+        run: bun test tests/unit
+
+      - name: E2E tests
+        if: steps.version.outputs.changed == 'true'
+        run: bun test tests/e2e
+
+      - name: Smoke (cpe doctor)
+        if: steps.version.outputs.changed == 'true'
+        run: bun run bin/sunat.ts -o json cpe doctor
+
+      - name: Publish to npm
+        if: steps.version.outputs.changed == 'true'
+        run: npm publish --access public
+
+      - name: Verify the published tarball runs
+        if: steps.version.outputs.changed == 'true'
+        working-directory: .
+        env:
+          VERSION: ${{ steps.version.outputs.local }}
+        run: |
+          for i in 1 2 3 4 5 6; do
+            if npm view "@crafter/sunat-cli@$VERSION" version >/dev/null 2>&1; then
+              break
+            fi
+            echo "Waiting for the registry to serve $VERSION ($i/6)"
+            sleep 10
+          done
+          WORKDIR=$(mktemp -d)
+          cd "$WORKDIR"
+          bun add "@crafter/sunat-cli@$VERSION"
+          INSTALLED=$(./node_modules/.bin/sunat-cli --version)
+          echo "Installed version: $INSTALLED"
+          test "$INSTALLED" = "$VERSION"
+          ./node_modules/.bin/sunat-cli --help | grep -q "cpe"
+
+      - name: Tag and GitHub Release
+        if: steps.version.outputs.changed == 'true'
+        working-directory: .
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.local }}
+        run: |
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+          gh release create "v$VERSION" --title "v$VERSION" --generate-notes

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Agent-first CLI for SUNAT tax automation in Peru. Built for AI agents as primary
 
 | Domain | Coverage | Surface |
 |--------|----------|---------|
-| **REST APIs** (Consulta CPE, Padrón RUC, Tipo Cambio SBS) | 90% | OAuth2 client_credentials + scrape |
+| **REST APIs** (Consulta CPE, Padrón RUC, Tipo Cambio SBS) | 90% | OAuth2 client_credentials + scrape (`cpe consulta`, `padron`, `tipo-cambio`) |
 | **RHE + F616** (personas naturales, RUC 10) | 95% | agent-browser, no CAPTCHA |
 | **CPE Factura / Boleta / NC / ND** | 85% | UBL 2.1 + XAdES-BES + SOAP directo |
 | **Resumen Diario + Comunicación de Baja** | 80% | sendSummary + ticket polling |
@@ -33,9 +33,24 @@ Agent-first CLI for SUNAT tax automation in Peru. Built for AI agents as primary
 bun add -g @crafter/sunat-cli
 ```
 
+Run `sunat-cli --help` after installing. That list is the contract: every command
+it prints is available in the version you have.
+
 ## Usage
 
-### CPE — Comprobantes Electrónicos (empresas, RUC 20)
+Each section below says which surface it needs. `npm` means the published
+release; `source` means the command exists on `main` and ships in the next
+release. Check `sunat-cli --help` if you are unsure what your install has.
+
+To run the source-only commands today:
+
+```bash
+git clone https://github.com/crafter-research/sunat-cli
+cd sunat-cli && bun install
+bun run packages/cli/bin/sunat.ts --help
+```
+
+### CPE — Comprobantes Electrónicos (empresas, RUC 20) · `source`
 
 ```bash
 # Health check + driver info
@@ -66,39 +81,50 @@ sunat-cli cpe baja send --params @baja.json --yes
 # GRE — Guía de Remisión Remitente (modal 02)
 sunat-cli cpe gre emit --params @guia.json --yes
 sunat-cli cpe gre status --ticket 12345...
+
+# Consulta CPE (validación post-emisión, propia o de un proveedor)
+sunat-cli cpe consulta --tipo 01 --serie F001 --numero 1234
 ```
 
-### SIRE — Sistema Integrado de Registros Electrónicos
+### SIRE — Sistema Integrado de Registros Electrónicos · `source`
 
 ```bash
 # RVIE (Ventas)
-sunat-cli sire rvie periodos
-sunat-cli sire rvie propuesta --periodo 202504 --yes
-sunat-cli sire rvie ticket --id <ticket-id>
-sunat-cli sire rvie archivo --ticket <ticket-id>      # downloads ZIP
-sunat-cli sire rvie aceptar --periodo 202504 --yes
+sunat-cli sire ventas periodos
+sunat-cli sire ventas propuesta --periodo 202504
+sunat-cli sire ventas ticket --id <ticket-id>
+sunat-cli sire ventas archivo --ticket <ticket-id>    # downloads ZIP
 
 # RCE (Compras)
-sunat-cli sire rce propuesta --periodo 202504 --yes
-sunat-cli sire rce importar --periodo 202504 --file ./compras.txt --yes
+sunat-cli sire compras propuesta --periodo 202504
+sunat-cli sire compras importar --periodo 202504 --file ./compras.zip --yes
 ```
 
-### REST APIs
+### REST APIs · `npm`
 
 ```bash
-# Consulta CPE (validación post-emisión)
-sunat-cli api consulta --tipo 01 --serie F001 --numero 1234
+# OAuth2 token for the SUNAT REST APIs
+sunat-cli api token
+```
 
-# Padrón RUC (sync incremental + lookup local)
-sunat-cli api padron sync
-sunat-cli api padron lookup 20123456789
+### Padrón RUC + Tipo de Cambio · `source`
+
+```bash
+# Padrón RUC: download once (~370MB ZIP), then look up locally
+sunat-cli padron status
+sunat-cli padron sync
+sunat-cli padron ruc 20123456789
+sunat-cli padron batch --file ./rucs.csv
+
+# Single RUC without syncing the padrón (drives the portal, ~5-10s)
+sunat-cli padron ruc-online 20123456789
 
 # Tipo de Cambio SBS
 sunat-cli tipo-cambio --fecha hoy
 sunat-cli tipo-cambio --fecha 2026-04-29 --output json
 ```
 
-### RHE / F616 (personas naturales)
+### RHE / F616 (personas naturales) · `npm`
 
 ```bash
 # Login (browser, no CAPTCHA)
@@ -153,7 +179,7 @@ Tracked in GitHub issues — [milestones board](https://github.com/crafter-resea
 | P0 — Now | [#10 cpe void T3 + safety rail](https://github.com/crafter-research/sunat-cli/issues/10) |
 | P1 — Next | [#11 GRE modal 01 + Transportista](https://github.com/crafter-research/sunat-cli/issues/11) · [#12 Drivers nubefact + apisperu](https://github.com/crafter-research/sunat-cli/issues/12) · [#18 Live verification](https://github.com/crafter-research/sunat-cli/issues/18) |
 | P2 — Later | [#13 Driver facturador](https://github.com/crafter-research/sunat-cli/issues/13) · [#14 SIRE reportes complementarios](https://github.com/crafter-research/sunat-cli/issues/14) · [#15 sqlite padrón index](https://github.com/crafter-research/sunat-cli/issues/15) · [#16 CI smoke jobs](https://github.com/crafter-research/sunat-cli/issues/16) · [#17 TUS auto-resume](https://github.com/crafter-research/sunat-cli/issues/17) |
-| P3 — Backlog | [#19 Catálogos cacheados](https://github.com/crafter-research/sunat-cli/issues/19) · [#20 Audit log rotation](https://github.com/crafter-research/sunat-cli/issues/20) · [#21 Keychain integration](https://github.com/crafter-research/sunat-cli/issues/21) · [#22 Multi-RUC profiles](https://github.com/crafter-research/sunat-cli/issues/22) |
+| P3 — Backlog | [#19 Catálogos cacheados](https://github.com/crafter-research/sunat-cli/issues/19) · [#21 Keychain integration](https://github.com/crafter-research/sunat-cli/issues/21) · [#22 Multi-RUC profiles](https://github.com/crafter-research/sunat-cli/issues/22) |
 
 ## Research
 
@@ -170,6 +196,16 @@ packages/
   cli/       @crafter/sunat-cli — the CLI
   website/   sunat-cli.crafter.ing landing
 ```
+
+## Releasing
+
+Publishing is automatic. Bump `version` in `packages/cli/package.json` and merge
+that PR to `main`. The release workflow then runs the test suite, publishes to
+npm with OIDC trusted publishing (no token stored in the repo), installs the
+published tarball to confirm it runs and exposes the expected commands, and
+finally tags the commit and opens a GitHub Release.
+
+A merge that leaves `version` untouched publishes nothing.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ sunat-cli tipo-cambio --fecha hoy
 sunat-cli tipo-cambio --fecha 2026-04-29 --output json
 ```
 
+### Audit log · `source`
+
+```bash
+# Archive audit months older than the retention window
+sunat-cli audit compact
+
+# Delete archived months before a cutoff. Never runs on its own
+sunat-cli audit prune --before 2025-01
+```
+
 ### RHE / F616 (personas naturales) · `npm`
 
 ```bash

--- a/packages/cli/bin/sunat.ts
+++ b/packages/cli/bin/sunat.ts
@@ -12,13 +12,14 @@ import { createSchemaCommand } from "../src/commands/schema.ts";
 import { createSireCommand } from "../src/commands/sire/index.ts";
 import { createTipoCambioCommand } from "../src/commands/tipo-cambio.ts";
 import { createWhoamiCommand } from "../src/commands/whoami.ts";
+import pkg from "../package.json" with { type: "json" };
 
 const program = new Command();
 
 program
 	.name("sunat")
 	.description("Agent-first CLI for SUNAT tax automation")
-	.version("0.1.0")
+	.version(pkg.version)
 	.option("-o, --output <format>", "output format", "auto")
 	.hook("preAction", (thisCommand) => {
 		const opts = thisCommand.opts();


### PR DESCRIPTION
Publishing was manual and stopped at `0.1.6` on April 1, while `main` kept moving for 34 more commits. That gap is what @moshe-exe hit in #31.

## Release workflow

Mirrors the one in `crafter-station/trx`: merging a PR to `main` that changes `version` in `packages/cli/package.json` runs the suite, publishes to npm with OIDC trusted publishing, then tags and opens a GitHub Release. A merge that leaves the version alone publishes nothing.

One step trx does not have: it installs the published tarball and asserts the binary reports the version just published and exposes `cpe`. That is the exact drift that made this PR necessary, so the release now fails loudly if it happens again.

Requires the npm trusted publisher to be configured for `crafter-research/sunat-cli` with workflow `release.yml` and no environment set.

## README

Closes #31. Each Usage section is now tagged `npm` (in the published release) or `source` (on `main`, ships in the next release), with a clone snippet for the source-only commands.

Verified separately: several documented commands never existed on any branch.

| README said | Actual |
|---|---|
| `api consulta` | `cpe consulta` (`api` only has `token`) |
| `api padron sync` / `padron lookup` | `padron sync` / `padron ruc` (top level, plus `status`, `batch`, `ruc-online`) |
| `sire rvie` / `sire rce` | `sire ventas` / `sire compras` |
| `sire rvie aceptar` | does not exist, dropped |

`--version` was hardcoded to `0.1.0` and printed that while `package.json` said `0.1.6`. It now reads from `package.json`.

## Verification

- `bun test`: 325 pass, 2 skip, 0 fail
- `cpe doctor` smoke: exit 0
- All 24 commands documented in the README resolve against the binary (checked by script, 24/24 OK)
- `sunat-cli --version` now prints `0.1.6`

## Not in this PR

`main` exposes a `lukea` command. Deliberately left undocumented rather than removed, since dropping a command is your call. Worth deciding before the next release.