### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/sunat-cli",
-	"version": "0.1.6",
+	"version": "0.2.0",
 	"description": "Agent-first CLI for SUNAT tax automation",
 	"module": "bin/sunat.ts",
 	"type": "module",


### PR DESCRIPTION
First release off the OIDC workflow from #32, and the first publish since `0.1.6` on April 1.

36 commits behind the published release, including everything the README documented but npm never shipped: CPE (Factura, Boleta, NC, ND, GRE, Resumen, Baja), SIRE (RVIE Ventas + RCE Compras, TUS upload), Padrón RUC local, Tipo de Cambio, and audit log rotation.

Merging this fires the release: suite, npm publish via trusted publishing, install-and-verify of the published tarball, tag, GitHub Release.

The workflow has never run before, so this is also its first live test.

## Verification

- `bun test`: 327 pass, 2 skip, 0 fail
- `sunat-cli --version` prints `0.2.0`, read from `package.json`