### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,19 +38,11 @@ it prints is available in the version you have.
 
 ## Usage
 
-Each section below says which surface it needs. `npm` means the published
-release; `source` means the command exists on `main` and ships in the next
-release. Check `sunat-cli --help` if you are unsure what your install has.
+Every section below is tagged `npm`, meaning it ships in the published release.
+A section tagged `source` would exist on `main` only. Right now nothing is
+source-only: the published release matches `main`.
 
-To run the source-only commands today:
-
-```bash
-git clone https://github.com/crafter-research/sunat-cli
-cd sunat-cli && bun install
-bun run packages/cli/bin/sunat.ts --help
-```
-
-### CPE — Comprobantes Electrónicos (empresas, RUC 20) · `source`
+### CPE — Comprobantes Electrónicos (empresas, RUC 20) · `npm`
 
 ```bash
 # Health check + driver info
@@ -86,7 +78,7 @@ sunat-cli cpe gre status --ticket 12345...
 sunat-cli cpe consulta --tipo 01 --serie F001 --numero 1234
 ```
 
-### SIRE — Sistema Integrado de Registros Electrónicos · `source`
+### SIRE — Sistema Integrado de Registros Electrónicos · `npm`
 
 ```bash
 # RVIE (Ventas)
@@ -107,7 +99,7 @@ sunat-cli sire compras importar --periodo 202504 --file ./compras.zip --yes
 sunat-cli api token
 ```
 
-### Padrón RUC + Tipo de Cambio · `source`
+### Padrón RUC + Tipo de Cambio · `npm`
 
 ```bash
 # Padrón RUC: download once (~370MB ZIP), then look up locally
@@ -124,9 +116,31 @@ sunat-cli tipo-cambio --fecha hoy
 sunat-cli tipo-cambio --fecha 2026-04-29 --output json
 ```
 
-### Audit log · `source`
+### Secrets · `npm`
+
+Secrets resolve from the environment first, then the OS keychain. Existing
+env-var setups keep working unchanged.
 
 ```bash
+sunat-cli keychain set CPE_CERT_PASSWORD --value '...'
+sunat-cli keychain list
+sunat-cli keychain clear CPE_CERT_PASSWORD
+```
+
+### Multi-emisor profiles · `npm`
+
+```bash
+sunat-cli cpe profile set --name acme --ruc 20123456789 --razon-social "ACME SAC" --mode beta
+sunat-cli cpe profile list
+sunat-cli cpe profile use acme
+```
+
+### Audit log · `npm`
+
+```bash
+# Inspect, optionally scoped to one emisor
+sunat-cli audit list --ruc 20123456789 --limit 20
+
 # Archive audit months older than the retention window
 sunat-cli audit compact
 
@@ -186,10 +200,10 @@ Tracked in GitHub issues — [milestones board](https://github.com/crafter-resea
 
 | Priority | Issues |
 |----------|--------|
-| P0 — Now | [#10 cpe void T3 + safety rail](https://github.com/crafter-research/sunat-cli/issues/10) |
-| P1 — Next | [#11 GRE modal 01 + Transportista](https://github.com/crafter-research/sunat-cli/issues/11) · [#12 Drivers nubefact + apisperu](https://github.com/crafter-research/sunat-cli/issues/12) · [#18 Live verification](https://github.com/crafter-research/sunat-cli/issues/18) |
+| P0 — Now | [#18 Live verification against production](https://github.com/crafter-research/sunat-cli/issues/18) |
+| P1 — Next | [#10 cpe void T3 + safety rail](https://github.com/crafter-research/sunat-cli/issues/10) · [#12 Drivers nubefact + apisperu](https://github.com/crafter-research/sunat-cli/issues/12) · [#11 GRE modal 01 + Transportista](https://github.com/crafter-research/sunat-cli/issues/11) |
 | P2 — Later | [#13 Driver facturador](https://github.com/crafter-research/sunat-cli/issues/13) · [#14 SIRE reportes complementarios](https://github.com/crafter-research/sunat-cli/issues/14) · [#15 sqlite padrón index](https://github.com/crafter-research/sunat-cli/issues/15) · [#16 CI smoke jobs](https://github.com/crafter-research/sunat-cli/issues/16) · [#17 TUS auto-resume](https://github.com/crafter-research/sunat-cli/issues/17) |
-| P3 — Backlog | [#19 Catálogos cacheados](https://github.com/crafter-research/sunat-cli/issues/19) · [#21 Keychain integration](https://github.com/crafter-research/sunat-cli/issues/21) · [#22 Multi-RUC profiles](https://github.com/crafter-research/sunat-cli/issues/22) |
+| P3 — Backlog | [#30 F.1683 arrendamiento](https://github.com/crafter-research/sunat-cli/issues/30) |
 
 ## Research
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/sunat-cli",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"description": "Agent-first CLI for SUNAT tax automation",
 	"module": "bin/sunat.ts",
 	"type": "module",


### PR DESCRIPTION
Ships the three P3 branches that had been drafts since May 2: catalog cache (#19), keychain secrets (#21), and multi-emisor profiles (#22).

## Why #28 was red for three months

It imported `../../cpe/catalogos/index.ts`, a module that only ever existed in #29. Three AFK agents branched from the same `main` in parallel and one ended up depending on a sibling PR. It could never pass CI alone, no matter how many times it ran. Merging #29 first fixed it with no code change.

## Verified by running it

- Catalog: an unknown `unidad` (`ZZZ`) produces `CAT_03_UNKNOWN` in `catalogCoverage`, and the preview still returns a hash with `dryRun: true`, exit 0. It warns, it does not block, which matters because SUNAT adds codes and a stale cache must not break emission.
- Keychain: full `set` / `get` / `list` / `clear` cycle against the real macOS keychain, confirmed with `security find-generic-password` directly after `clear`. Secrets resolve env-first, keychain second, so existing env setups are untouched.
- Profiles: created two emisores, switched with `cpe profile use`, confirmed `defaultProfile` persisted to `~/.sunat/cpe.json`. Test profiles cleaned up afterward.
- `bun test`: 332 pass, 2 skip, 0 fail
- All 31 commands documented in the README resolve against the binary

## Roadmap change

#18 moves to P0, #10 drops to P1.

Voiding already works today through `cpe nc emit` and `cpe baja send`, so the T3 intent-token flow is orchestration and a guard rail on top of a working capability. Production has never been touched at all, which is the thing that keeps this from being usable for a real filing. That ordering was backwards.