### PR TITLE
fix(release): poll the registry with the client that installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,16 +77,22 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.local }}
         run: |
-          for i in 1 2 3 4 5 6; do
-            if npm view "@crafter/sunat-cli@$VERSION" version >/dev/null 2>&1; then
-              break
-            fi
-            echo "Waiting for the registry to serve $VERSION ($i/6)"
-            sleep 10
-          done
           WORKDIR=$(mktemp -d)
           cd "$WORKDIR"
-          bun add "@crafter/sunat-cli@$VERSION"
+          # Poll with the same client that installs. `npm view` sees the new
+          # version before Bun's metadata cache does, so waiting on npm and
+          # then installing with Bun races and fails on a fresh publish.
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if bun add "@crafter/sunat-cli@$VERSION" 2>/dev/null; then
+              break
+            fi
+            if [ "$i" = "10" ]; then
+              echo "Registry never served $VERSION to bun after 10 attempts"
+              bun add "@crafter/sunat-cli@$VERSION"
+            fi
+            echo "Waiting for the registry to serve $VERSION to bun ($i/10)"
+            sleep 15
+          done
           INSTALLED=$(./node_modules/.bin/sunat-cli --version)
           echo "Installed version: $INSTALLED"
           test "$INSTALLED" = "$VERSION"
@@ -99,6 +105,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.local }}
         run: |
-          git tag "v$VERSION"
-          git push origin "v$VERSION"
-          gh release create "v$VERSION" --title "v$VERSION" --generate-notes
+          if ! git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            git tag "v$VERSION"
+            git push origin "v$VERSION"
+          fi
+          if ! gh release view "v$VERSION" >/dev/null 2>&1; then
+            gh release create "v$VERSION" --title "v$VERSION" --generate-notes
+          fi


### PR DESCRIPTION
The `0.4.1` release published to npm and then failed its own verification step.

`npm view @crafter/sunat-cli@0.4.1` already resolved while `bun add` still reported `No version matching "0.4.1" found ... (but package exists)`. The wait loop asked npm and the install used bun, so it raced against bun's metadata cache on a fresh publish.

The package itself was fine. The check was wrong. Because the step failed, tagging and the GitHub Release were skipped and I created `v0.4.1` by hand.

## Changes

- The retry loop now runs `bun add` directly, so the thing that waits is the thing that installs. Ten attempts, 15s apart, and the last one runs unsuppressed so a real failure still shows its error.
- Tagging and release creation are idempotent. Re-running a release whose publish already succeeded no longer dies on an existing tag, which is exactly the state `0.4.1` was left in.

## Verification

This one only proves itself on the next release. `0.4.1` is already published and installs cleanly (`bun add @crafter/sunat-cli@0.4.1` then `--version` prints `0.4.1`), and its tag and release now exist.