### PR TITLE
fix(soap): surface SUNAT's text reason instead of failing inside the unzip

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/sunat-cli",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Agent-first CLI for SUNAT tax automation",
 	"module": "bin/sunat.ts",
 	"type": "module",

--- a/packages/cli/src/cpe/soap/client.ts
+++ b/packages/cli/src/cpe/soap/client.ts
@@ -230,6 +230,13 @@ export async function getStatus(args: GetStatusArgs): Promise<GetStatusOutcome> 
 	}
 
 	const cdrZipBuffer = Buffer.from(content, "base64");
+	// SUNAT puts a plain-text reason in <content> for error codes instead of a
+	// base64 CDR zip (e.g. statusCode 0127 -> "El ticket no existe"). Decoding
+	// that as base64 yields garbage, so surface the reason instead of failing
+	// inside the unzip with "not a zip file".
+	if (cdrZipBuffer.subarray(0, 2).toString("ascii") !== "PK") {
+		throw new Error(`SUNAT getStatus ${statusCode}: ${content.trim()}`);
+	}
 	const { xml: cdrXml } = await unzipNested(cdrZipBuffer);
 	const cdr = parseCdr(cdrXml);
 	const accepted = statusCode === "0" && cdr.accepted;

--- a/packages/cli/tests/unit/soap-envelope.test.ts
+++ b/packages/cli/tests/unit/soap-envelope.test.ts
@@ -104,6 +104,17 @@ describe("postSoap empty-body guard", () => {
 		).rejects.toThrow(/empty body/i);
 	});
 
+	test("a text reason in <content> surfaces as an error, not as a zip failure", async () => {
+		// Real beta response to getStatus with a ticket that does not exist.
+		const envelope =
+			'<S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><ns2:getStatusResponse xmlns:ns2="http://service.sunat.gob.pe"><status><content>El ticket no existe</content><statusCode>0127</statusCode></status></ns2:getStatusResponse></S:Body></S:Envelope>';
+		globalThis.fetch = (async () => new Response(envelope, { status: 200 })) as typeof fetch;
+
+		await expect(getStatus({ mode: "beta", wsUsername: "u", wsPassword: "p", ticket: "1" })).rejects.toThrow(
+			/0127.*El ticket no existe/,
+		);
+	});
+
 	test("a non-empty response is still parsed normally", async () => {
 		const envelope =
 			'<S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Body><ns2:getStatusResponse xmlns:ns2="http://service.sunat.gob.pe"><status><statusCode>98</statusCode></status></ns2:getStatusResponse></S:Body></S:Envelope>';


### PR DESCRIPTION
Found while verifying the `0.4.1` fix against the real servers, not against a mock.

Calling `getStatus` on beta with a ticket that does not exist returns:

```xml
<status><content>El ticket no existe</content><statusCode>0127</statusCode></status>
```

`content` is plain text there, where a base64 CDR zip normally goes. The code decoded it as base64 anyway and passed the result to the unzip, so the user got:

```
End of central directory record signature not found. Either not a zip file, or file is truncated.
```

instead of the reason SUNAT actually gave. Only statusCodes `98`, `0` and `99` were handled; every other code carrying a text body landed here.

The content is now checked for the `PK` magic bytes before unzipping, and a non-zip payload is raised as `SUNAT getStatus 0127: El ticket no existe`.

## Verification

- The test uses the exact envelope beta returned. Confirmed it **fails without the fix and passes with it**.
- Full suite: 335 pass, 2 skip, 0 fail.
- Also re-confirmed the `0.4.1` guard against real production: `e-factura` now raises `SUNAT returned HTTP 200 with an empty body...` instead of reporting `processing` and spinning for five minutes.