### PR TITLE
fix(release): give the registry minutes, not seconds, to serve a publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,19 +79,20 @@ jobs:
         run: |
           WORKDIR=$(mktemp -d)
           cd "$WORKDIR"
-          # Poll with the same client that installs. `npm view` sees the new
-          # version before Bun's metadata cache does, so waiting on npm and
-          # then installing with Bun races and fails on a fresh publish.
-          for i in 1 2 3 4 5 6 7 8 9 10; do
+          # Poll with the same client that installs. `npm view` serves a fresh
+          # publish well before Bun's registry view catches up: 0.4.1 and 0.4.2
+          # both published fine and then failed here, the second one after
+          # 2.5 minutes of retries, so the window is minutes and not seconds.
+          for i in $(seq 1 30); do
             if bun add "@crafter/sunat-cli@$VERSION" 2>/dev/null; then
               break
             fi
-            if [ "$i" = "10" ]; then
-              echo "Registry never served $VERSION to bun after 10 attempts"
+            if [ "$i" = "30" ]; then
+              echo "Registry never served $VERSION to bun after 30 attempts"
               bun add "@crafter/sunat-cli@$VERSION"
             fi
-            echo "Waiting for the registry to serve $VERSION to bun ($i/10)"
-            sleep 15
+            echo "Waiting for the registry to serve $VERSION to bun ($i/30)"
+            sleep 20
           done
           INSTALLED=$(./node_modules/.bin/sunat-cli --version)
           echo "Installed version: $INSTALLED"


### PR DESCRIPTION
`0.4.1` and `0.4.2` both published to npm and then failed their own verification step, so neither got tagged automatically and I created both tags by hand.

`npm view` resolves a fresh publish well before `bun add` does. The retry loop already used bun (fixed in #37), but 10 attempts at 15s was not enough: `0.4.2` still failed after the full 2.5 minutes.

## A hypothesis I tested and dropped

I assumed bun was caching the manifest it had just failed to resolve, and was about to give every retry its own `BUN_INSTALL_CACHE_DIR`. Measured it first:

1. `bun add pkg@9.9.9` with a fixed cache dir, fails as expected
2. `bun add pkg@0.4.2` with **the same** cache dir, installs fine

So bun does not persist the negative result, and that workaround would have been noise dressed as a fix. It is not in this change.

What the evidence actually supports is propagation latency measured in minutes, so the window goes to 30 attempts at 20s (10 minutes).

## Verification

`0.4.2` is published and installs cleanly (`--version` prints `0.4.2`, `--help` lists `cpe`), and its tag and release now exist. Like #37, this one only proves itself on the next release.