### PR TITLE
docs: F616 periodo is YYYY-MM, not MM/YYYY

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,12 @@ sunat-cli rhe emit --dry-run --json '{"empresa":"Acme Corp.","monto":5000,"moned
 # Batch emit
 sunat-cli rhe emit --batch ./data/example.csv
 
-# F616 mensual
-sunat-cli f616 declare --json '{"periodo":"03/2025"}'
+# F616 mensual (periodo en YYYY-MM)
+sunat-cli f616 declare --dry-run --json '{"periodo":"2026-03","ingresoPEN":5000}'
+sunat-cli f616 declare --json '{"periodo":"2026-03","ingresoPEN":5000}'
+
+# Varios periodos de una
+sunat-cli f616 declare --batch --months 2025-03..2026-02 --dry-run
 ```
 
 ## Design


### PR DESCRIPTION
The README documented `{"periodo":"03/2025"}`. The CLI rejects it:

```
$ sunat-cli f616 declare --dry-run --json '{"periodo":"03/2026","ingresoPEN":5000}'
{"success": false, "error": "Invalid periodo: must be YYYY-MM format, got \"03/2026\""}

$ sunat-cli f616 declare --dry-run --json '{"periodo":"2026-03","ingresoPEN":5000}'
{"dryRun": true, "periodo": "2026-03", "status": "would-declare"}
```

Found while preparing the production run for #18. A wrong example in the docs is cheap to fix now and expensive during a live filing.

Also documents `--batch --months 2025-03..2026-02`, which was implemented but missing from the README. Verified it expands to one record per month.