### PR TITLE
feat(keychain): prompt for the secret instead of demanding it as a flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ Secrets resolve from the environment first, then the OS keychain. Existing
 env-var setups keep working unchanged.
 
 ```bash
-sunat-cli keychain set CPE_CERT_PASSWORD --value '...'
+# Omit --value on a terminal and it prompts without echo, so the secret
+# never lands in shell history
+sunat-cli keychain set CPE_CERT_PASSWORD
 sunat-cli keychain list
 sunat-cli keychain clear CPE_CERT_PASSWORD
 ```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/sunat-cli",
-	"version": "0.4.2",
+	"version": "0.5.0",
 	"description": "Agent-first CLI for SUNAT tax automation",
 	"module": "bin/sunat.ts",
 	"type": "module",

--- a/packages/cli/src/commands/keychain.ts
+++ b/packages/cli/src/commands/keychain.ts
@@ -1,3 +1,4 @@
+import * as p from "@clack/prompts";
 import { Command } from "commander";
 import { clearKeychainSecret, getKeychainSecret, listKeychainSecrets, setKeychainSecret } from "../data/keychain.ts";
 import { output, outputError } from "../utils/output.ts";
@@ -21,11 +22,24 @@ export function createKeychainCommand(): Command {
 		.command("set")
 		.description("Store a secret in the OS keychain.")
 		.argument("<key>", "Secret env var name, e.g. CPE_CERT_PASSWORD")
-		.requiredOption("--value <secret>", "Secret value")
-		.action((key, opts, cmd) => {
+		.option("--value <secret>", "Secret value. Omit it on a TTY to be prompted without echo.")
+		.action(async (key, opts, cmd) => {
 			const format = getFormat(cmd);
 			try {
-				setKeychainSecret(key, opts.value);
+				let value = opts.value;
+				if (!value) {
+					if (!process.stdin.isTTY) {
+						outputError(`Pass --value, or run this on a terminal to be prompted for ${key}.`, format);
+						return;
+					}
+					const entered = await p.password({ message: `Value for ${key}` });
+					if (p.isCancel(entered)) {
+						p.cancel("Cancelled");
+						process.exit(0);
+					}
+					value = entered as string;
+				}
+				setKeychainSecret(key, value);
 				output(format, {
 					json: { success: true, key },
 					table: { headers: ["Key", "Status"], rows: [[key, "stored"]] },


### PR DESCRIPTION
`keychain set` declared `--value` as a required option, so storing a password meant typing it into the command line:

```
$ sunat-cli keychain set SUNAT_PASSWORD
error: required option '--value <secret>' not specified
```

That puts the secret in shell history, the process table, and any transcript of the session. A command whose entire job is keeping a secret out of a plaintext file should not force it through argv to get there.

## Change

`--value` is now optional and still works for scripts. Omitted on a TTY, the value is prompted without echo through the same `@clack/prompts` password flow `login` already uses. Without a TTY and without `--value`, it errors rather than hanging on a prompt nobody can answer.

## Verification

```
--value given            -> {"success": true, "key": "SUNAT_API_CLIENT_SECRET"}
no --value, stdin closed -> {"success": false, "error": "Pass --value, or run this on a terminal..."}
clear afterwards         -> {"cleared": true}
```

Full suite: 335 pass, 2 skip, 0 fail.

Found while setting up the production run for #18, where the first thing the runbook asks for is exactly this command.