### PR TITLE
fix(sire,gre): resolve client_id and RUC from config, not just env vars

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/sunat-cli",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "Agent-first CLI for SUNAT tax automation",
 	"module": "bin/sunat.ts",
 	"type": "module",

--- a/packages/cli/src/commands/cpe/index.ts
+++ b/packages/cli/src/commands/cpe/index.ts
@@ -1,5 +1,4 @@
 import { Command } from "commander";
-import { audit } from "../../data/audit.ts";
 import { clearQueueForEmisor, enqueueBoleta, listQueueDates, readQueue } from "../../cpe/boleta-queue.ts";
 import { buildCatalogCoverageReport, hasCatalogWarnings } from "../../cpe/catalogos/index.ts";
 import { loadCpeConfig, resolveCpeAuditContext, resolveCpeContext, saveCpeConfig } from "../../cpe/config.ts";
@@ -7,6 +6,8 @@ import { getDriver } from "../../cpe/drivers/index.ts";
 import type { CpeDriverName } from "../../cpe/drivers/types.ts";
 import { parseFacturaInput, parseNotaInput } from "../../cpe/parsers.ts";
 import { boletaRequiresIndividualSubmission } from "../../cpe/ubl/boleta.ts";
+import { audit } from "../../data/audit.ts";
+import { loadConfig } from "../../data/config.ts";
 import { resolveSecret } from "../../data/keychain.ts";
 import { output, outputError } from "../../utils/output.ts";
 
@@ -55,7 +56,10 @@ export function createCpeCommand(): Command {
 		"Comprobantes de Pago Electronicos (CPE) for empresas con RUC 20. Factura, Boleta, NC, ND, Guia. NOT for personas naturales — use 'sunat rhe'.",
 	);
 
-	cpe.option("--driver <name>", "Backend driver: mock|facturador|sunat-direct|nubefact|apisperu (default: mock or $CPE_DRIVER)");
+	cpe.option(
+		"--driver <name>",
+		"Backend driver: mock|facturador|sunat-direct|nubefact|apisperu (default: mock or $CPE_DRIVER)",
+	);
 
 	cpe
 		.command("doctor")
@@ -98,7 +102,12 @@ export function createCpeCommand(): Command {
 				const result = await driver.previewFactura(input);
 				const catalogCoverage = buildCatalogCoverageReport(input);
 				if (hasCatalogWarnings(catalogCoverage)) result.catalogCoverage = catalogCoverage;
-				audit({ command: "cpe factura preview", args: input as unknown as Record<string, unknown>, result: "dry-run", details: { hash: result.hash } });
+				audit({
+					command: "cpe factura preview",
+					args: input as unknown as Record<string, unknown>,
+					result: "dry-run",
+					details: { hash: result.hash },
+				});
 				output(format, { json: { dryRun: true, ...result } });
 			} catch (err) {
 				outputError(err instanceof Error ? err.message : String(err), format);
@@ -199,7 +208,9 @@ export function createCpeCommand(): Command {
 
 	boleta
 		.command("emit")
-		.description("Emit a Boleta individually (only when total >= S/700). For total<S/700 use 'cpe boleta queue' + 'cpe resumen send'. T2.")
+		.description(
+			"Emit a Boleta individually (only when total >= S/700). For total<S/700 use 'cpe boleta queue' + 'cpe resumen send'. T2.",
+		)
 		.requiredOption("--params <json>")
 		.option("--dry-run")
 		.option("--yes")
@@ -294,8 +305,7 @@ export function createCpeCommand(): Command {
 
 	const nc = cpe.command("nc").description("Nota de Credito (CPE tipo 07) operations.");
 
-	nc
-		.command("emit")
+	nc.command("emit")
 		.description("Emit a Nota de Credito. T2.")
 		.requiredOption("--params <json>")
 		.option("--dry-run")
@@ -334,8 +344,7 @@ export function createCpeCommand(): Command {
 
 	const nd = cpe.command("nd").description("Nota de Debito (CPE tipo 08) operations.");
 
-	nd
-		.command("emit")
+	nd.command("emit")
 		.description("Emit a Nota de Debito. T2.")
 		.requiredOption("--params <json>")
 		.option("--dry-run")
@@ -372,7 +381,9 @@ export function createCpeCommand(): Command {
 			}
 		});
 
-	const gre = cpe.command("gre").description("Guía de Remisión Electrónica (CPE tipo 09) — REST OAuth, NOT SOAP. T0/T2.");
+	const gre = cpe
+		.command("gre")
+		.description("Guía de Remisión Electrónica (CPE tipo 09) — REST OAuth, NOT SOAP. T0/T2.");
 	cpe
 		.command("guia")
 		.description("Alias for 'cpe gre' — kept for backwards naming.")
@@ -385,9 +396,7 @@ export function createCpeCommand(): Command {
 
 	gre
 		.command("emit")
-		.description(
-			"Sign + zip + base64 + POST a Guía de Remisión via SUNAT GRE REST API. Async — returns ticket. T2.",
-		)
+		.description("Sign + zip + base64 + POST a Guía de Remisión via SUNAT GRE REST API. Async — returns ticket. T2.")
 		.requiredOption("--params <json>", "JSON payload (run: sunat schema cpe-gre)")
 		.option("--dry-run", "Build + sign locally, do NOT submit")
 		.option("--yes", "Skip T2 confirmation")
@@ -433,7 +442,7 @@ export function createCpeCommand(): Command {
 				}
 
 				// Need OAuth credentials (client_id/secret + RUC + SOL pwd)
-				const clientId = process.env.SUNAT_GRE_CLIENT_ID || process.env.SUNAT_API_CLIENT_ID;
+				const clientId = process.env.SUNAT_GRE_CLIENT_ID || process.env.SUNAT_API_CLIENT_ID || loadConfig().apiClientId;
 				const clientSecret = resolveSecret(["SUNAT_GRE_CLIENT_SECRET", "SUNAT_API_CLIENT_SECRET"]);
 				if (!clientId || !clientSecret) {
 					outputError(
@@ -443,7 +452,10 @@ export function createCpeCommand(): Command {
 					return;
 				}
 				if (!ctx.solUsuario || !ctx.solPassword) {
-					outputError("GRE needs SOL usuario + password (CPE_SOL_USUARIO env var plus CPE_SOL_PASSWORD/SUNAT_PASSWORD env var or keychain secret).", format);
+					outputError(
+						"GRE needs SOL usuario + password (CPE_SOL_USUARIO env var plus CPE_SOL_PASSWORD/SUNAT_PASSWORD env var or keychain secret).",
+						format,
+					);
 					return;
 				}
 				const greCreds = greCredentials({
@@ -469,7 +481,12 @@ export function createCpeCommand(): Command {
 							hint: `Poll status with: sunat cpe gre status --ticket ${sendResp.numTicket}`,
 						},
 					});
-					audit({ command: "cpe gre emit", args: input as Record<string, unknown>, result: "success", details: auditDetails });
+					audit({
+						command: "cpe gre emit",
+						args: input as Record<string, unknown>,
+						result: "success",
+						details: auditDetails,
+					});
 					return;
 				}
 
@@ -509,10 +526,13 @@ export function createCpeCommand(): Command {
 				const { resolveCpeContext } = await import("../../cpe/config.ts");
 				const { greCredentials, consultarGreTicket, pollGreTicket } = await import("../../sunat-rest/gre.ts");
 				const ctx = resolveCpeContext();
-				const clientId = process.env.SUNAT_GRE_CLIENT_ID || process.env.SUNAT_API_CLIENT_ID;
+				const clientId = process.env.SUNAT_GRE_CLIENT_ID || process.env.SUNAT_API_CLIENT_ID || loadConfig().apiClientId;
 				const clientSecret = resolveSecret(["SUNAT_GRE_CLIENT_SECRET", "SUNAT_API_CLIENT_SECRET"]);
 				if (!clientId || !clientSecret) {
-					outputError("Missing SUNAT_GRE_CLIENT_ID env var and SUNAT_GRE_CLIENT_SECRET/SUNAT_API_CLIENT_SECRET env var or keychain secret.", format);
+					outputError(
+						"Missing SUNAT_GRE_CLIENT_ID env var and SUNAT_GRE_CLIENT_SECRET/SUNAT_API_CLIENT_SECRET env var or keychain secret.",
+						format,
+					);
 					return;
 				}
 				const greCreds = greCredentials({
@@ -580,9 +600,10 @@ export function createCpeCommand(): Command {
 						tipoDoc: "03" as const,
 						serie: q.input.serie,
 						numero: q.input.numero,
-						receptor: q.input.receptor && q.input.receptor.numDoc
-							? { tipoDoc: q.input.receptor.tipoDoc, numDoc: q.input.receptor.numDoc }
-							: undefined,
+						receptor:
+							q.input.receptor && q.input.receptor.numDoc
+								? { tipoDoc: q.input.receptor.tipoDoc, numDoc: q.input.receptor.numDoc }
+								: undefined,
 						totales: q.input.totales,
 						moneda: q.input.moneda,
 					})),
@@ -699,7 +720,10 @@ export function createCpeCommand(): Command {
 	baja
 		.command("send")
 		.description("Send Comunicacion de Baja for one or more documents. Async — returns ticket. T2.")
-		.requiredOption("--params <json>", "JSON: { fechaEmisionDocs, fechaComunicacion?, correlativo?, entries: [{tipoDoc,serie,numero,motivo}, ...] }")
+		.requiredOption(
+			"--params <json>",
+			"JSON: { fechaEmisionDocs, fechaComunicacion?, correlativo?, entries: [{tipoDoc,serie,numero,motivo}, ...] }",
+		)
 		.option("--yes", "Skip T2 confirmation prompt")
 		.option("--wait", "Poll getStatus until completed/rejected")
 		.option("--timeout <ms>", "Polling timeout (default 300000 = 5min)", "300000")
@@ -811,10 +835,7 @@ export function createCpeCommand(): Command {
 						const ctx = resolveCpeContext();
 						rucConsultante = ctx.emisor.ruc;
 					} catch {
-						outputError(
-							"--ruc-consultante required (could not resolve from CPE_EMISOR_RUC or active profile)",
-							format,
-						);
+						outputError("--ruc-consultante required (could not resolve from CPE_EMISOR_RUC or active profile)", format);
 						return;
 					}
 				}

--- a/packages/cli/src/commands/sire/index.ts
+++ b/packages/cli/src/commands/sire/index.ts
@@ -1,20 +1,19 @@
 import { Command } from "commander";
-import { writeFileSync } from "fs";
-import { audit } from "../../data/audit.ts";
-import { readFileSync as readFile, statSync as fileStat } from "fs";
+import { statSync as fileStat, readFileSync as readFile, writeFileSync } from "fs";
 import { basename } from "path";
-import { missingSecretMessage, resolveSecret } from "../../data/keychain.ts";
+import { audit } from "../../data/audit.ts";
+import { getApiCredentials, getCredentials } from "../../data/config.ts";
 import {
+	aceptarPropuestaRvie,
 	COD_LIBRO,
 	type CodLibro,
-	type SireUploadKind,
-	aceptarPropuestaRvie,
 	consultarTicket,
 	descargarArchivo,
 	descargarPropuesta,
 	descargarRvie,
 	listarPeriodos,
 	pollTicket,
+	type SireUploadKind,
 	sireCredentials,
 	sireUpload,
 } from "../../sunat-rest/sire.ts";
@@ -33,16 +32,11 @@ function getFormat(cmd: Command): Format {
 }
 
 function resolveSireCreds(): ReturnType<typeof sireCredentials> {
-	const clientId = process.env.SUNAT_API_CLIENT_ID;
-	const clientSecret = resolveSecret(["SUNAT_API_CLIENT_SECRET"]);
-	const ruc = process.env.SUNAT_RUC || process.env.CPE_EMISOR_RUC;
-	const solUsuario = process.env.SUNAT_USER || process.env.CPE_SOL_USUARIO;
-	const solPassword = resolveSecret(["SUNAT_PASSWORD", "CPE_SOL_PASSWORD"]);
-	if (!clientId) throw new Error("SUNAT_API_CLIENT_ID env var missing (from SOL → Credenciales API SUNAT, MIGE RCE y RVIE - SIRE)");
-	if (!clientSecret) throw new Error(missingSecretMessage(["SUNAT_API_CLIENT_SECRET"], "SUNAT_API_CLIENT_SECRET"));
-	if (!ruc) throw new Error("SUNAT_RUC env var missing");
-	if (!solUsuario) throw new Error("SUNAT_USER env var missing (SOL usuario, NOT the password)");
-	if (!solPassword) throw new Error(missingSecretMessage(["SUNAT_PASSWORD", "CPE_SOL_PASSWORD"], "Clave SOL"));
+	// clientId + secret resolve from env, then ~/.sunat/config.json, then keychain
+	// (getApiCredentials). RUC + SOL user + password come from the same place login
+	// stored them, so a logged-in user does not have to re-set env vars for SIRE.
+	const { clientId, clientSecret } = getApiCredentials();
+	const { ruc, usuario: solUsuario, password: solPassword } = getCredentials();
 	return sireCredentials({ clientId, clientSecret, ruc, solUsuario, solPassword });
 }
 
@@ -78,7 +72,12 @@ function bookCommand(libroAlias: "ventas" | "compras", codLibro: CodLibro): Comm
 				const numTicket = await descargarPropuesta({ codLibro, perTributario: opts.periodo }, creds);
 
 				if (!opts.wait) {
-					audit({ command: `sire ${libroAlias} propuesta`, args: { periodo: opts.periodo }, result: "success", details: { numTicket } });
+					audit({
+						command: `sire ${libroAlias} propuesta`,
+						args: { periodo: opts.periodo },
+						result: "success",
+						details: { numTicket },
+					});
 					output(format, {
 						json: {
 							numTicket,
@@ -95,7 +94,9 @@ function bookCommand(libroAlias: "ventas" | "compras", codLibro: CodLibro): Comm
 				});
 
 				if (result.state !== "completed") {
-					output(format, { json: { numTicket, state: result.state, statusCode: result.statusCode, statusDesc: result.statusDesc } });
+					output(format, {
+						json: { numTicket, state: result.state, statusCode: result.statusCode, statusDesc: result.statusDesc },
+					});
 					return;
 				}
 
@@ -130,7 +131,9 @@ function bookCommand(libroAlias: "ventas" | "compras", codLibro: CodLibro): Comm
 						state: result.state,
 						statusDesc: result.statusDesc,
 						archivoReporte: archivos,
-						hint: archivos[0] ? `Download with: sunat sire ${libroAlias} archivo --nombre ${archivos[0].nomArchivoReporte} --periodo ${opts.periodo} --out path` : undefined,
+						hint: archivos[0]
+							? `Download with: sunat sire ${libroAlias} archivo --nombre ${archivos[0].nomArchivoReporte} --periodo ${opts.periodo} --out path`
+							: undefined,
 					},
 				});
 			} catch (err) {
@@ -189,9 +192,7 @@ function bookCommand(libroAlias: "ventas" | "compras", codLibro: CodLibro): Comm
 
 	const uploadCommand = sub
 		.command("reemplazar")
-		.description(
-			"Reemplazar la propuesta SUNAT con un archivo .zip propio (TUS.IO upload, async). T2.",
-		)
+		.description("Reemplazar la propuesta SUNAT con un archivo .zip propio (TUS.IO upload, async). T2.")
 		.requiredOption("--periodo <YYYYMM>", "Periodo tributario, e.g. 202404")
 		.requiredOption("--file <path>", "Path to the .zip file to upload (must contain a .txt per SUNAT spec)")
 		.option("--filename <name>", "Override filename announced to SUNAT (defaults to basename of --file)")
@@ -209,10 +210,7 @@ function bookCommand(libroAlias: "ventas" | "compras", codLibro: CodLibro): Comm
 		)
 		.requiredOption("--periodo <YYYYMM>")
 		.requiredOption("--file <path>", "Path to the .zip file to upload")
-		.requiredOption(
-			"--tipo <kind>",
-			"propuesta | preliminar | ajustes | ajustes-anteriores",
-		)
+		.requiredOption("--tipo <kind>", "propuesta | preliminar | ajustes | ajustes-anteriores")
 		.option("--filename <name>")
 		.option("--yes")
 		.option("--wait")
@@ -235,7 +233,15 @@ function bookCommand(libroAlias: "ventas" | "compras", codLibro: CodLibro): Comm
 
 	async function uploadAction(
 		cmd: Command,
-		opts: { periodo: string; file: string; filename?: string; yes?: boolean; wait?: boolean; timeout: string; chunkSize: string },
+		opts: {
+			periodo: string;
+			file: string;
+			filename?: string;
+			yes?: boolean;
+			wait?: boolean;
+			timeout: string;
+			chunkSize: string;
+		},
 		kind: SireUploadKind,
 	): Promise<void> {
 		const format = getFormat(cmd);
@@ -346,8 +352,15 @@ function bookCommand(libroAlias: "ventas" | "compras", codLibro: CodLibro): Comm
 					}
 					const creds = resolveSireCreds();
 					const result = await aceptarPropuestaRvie(opts.periodo, creds);
-					audit({ command: "sire ventas aceptar", args: { periodo: opts.periodo }, result: "success", details: result as unknown as Record<string, unknown> });
-					output(format, { json: { ...result, hint: `Poll status with: sunat sire ventas ticket --num ${result.numTicket}` } });
+					audit({
+						command: "sire ventas aceptar",
+						args: { periodo: opts.periodo },
+						result: "success",
+						details: result as unknown as Record<string, unknown>,
+					});
+					output(format, {
+						json: { ...result, hint: `Poll status with: sunat sire ventas ticket --num ${result.numTicket}` },
+					});
 				} catch (err) {
 					outputError(err instanceof Error ? err.message : String(err), format);
 				}
@@ -395,7 +408,9 @@ function bookCommand(libroAlias: "ventas" | "compras", codLibro: CodLibro): Comm
 }
 
 export function createSireCommand(): Command {
-	const sire = new Command("sire").description("SUNAT SIRE — Registro de Ventas (RVIE) y Compras (RCE) electrónicos. T0/T1/T2.");
+	const sire = new Command("sire").description(
+		"SUNAT SIRE — Registro de Ventas (RVIE) y Compras (RCE) electrónicos. T0/T1/T2.",
+	);
 	sire.addCommand(bookCommand("ventas", COD_LIBRO.rvie));
 	sire.addCommand(bookCommand("compras", COD_LIBRO.rce));
 	return sire;


### PR DESCRIPTION
`sire ventas periodos` failed with `SUNAT_API_CLIENT_ID env var missing` even after `login`, because SIRE read its credentials straight from `process.env` and ignored the config that `login` writes to `~/.sunat/config.json`.

## Change

SIRE now resolves through `getApiCredentials()` + `getCredentials()`, the same accessors CPE already uses. Those fall back **env -> config -> keychain**, so a logged-in user with a registered client does not have to re-export env vars.

GRE keeps its GRE-specific `SUNAT_GRE_CLIENT_ID` first (a user can register a separate GRE client) and gains the same `config.apiClientId` fallback at the end of the chain.

## Verified against production

```
$ sunat-cli sire ventas periodos
{"codLibro": "140000", "ejercicios": []}
```

200, authenticated with only a `client_id` in config and the secret in the keychain. Before this, it errored before making any call. (`ejercicios` is empty because this RUC is a persona natural with no SIRE history, but the call reached SUNAT and returned.)

`bun test`: 338 pass, 2 skip, 0 fail. The one preexisting unused-variable warning in cpe/index.ts (`resolveOAuthCredentials`) is not touched by this change.