### PR TITLE
fix(tipo-cambio): honor --fecha by querying the month endpoint

### DIFF
--- a/packages/cli/src/sunat-rest/tipo-cambio.ts
+++ b/packages/cli/src/sunat-rest/tipo-cambio.ts
@@ -1,22 +1,30 @@
 /**
- * Tipo de Cambio SUNAT — daily official rate scraper.
+ * Tipo de Cambio SUNAT — daily official rate.
  *
- * SUNAT publishes the official TC at:
- *   https://e-consulta.sunat.gob.pe/cl-at-ittipcam/tcS01Alias
+ * SUNAT's TC page (https://e-consulta.sunat.gob.pe/cl-at-ittipcam/tcS01Alias)
+ * renders a calendar whose data comes from a JSON endpoint:
  *
- * Direct fetch is blocked by SUNAT's WAF (returns "Request Rejected").
- * Workaround: drive a real Chrome session via `agent-browser`, pull the
- * rendered HTML/snapshot, parse the compra/venta values from the table.
+ *   POST /cl-at-ittipcam/tcS01Alias/listarTipoCambio
+ *   body: {"anio": 2025, "mes": 10, "token": "..."}
+ *   -> [{"fecPublica":"01/11/2025","valTipo":"3.372","codTipo":"C"}, ...]
+ *
+ * Notes on the contract, measured 2026-08-22:
+ *  - `mes` is ZERO-INDEXED (JS getMonth()): mes=10 returns November.
+ *  - `codTipo` is "C" (compra) or "V" (venta). Each date yields two rows.
+ *  - `token` is a reCAPTCHA v3 token in the browser, but the endpoint does
+ *    not reject requests carrying a dummy value.
+ *  - The WAF rejects requests without browser-like headers. A plain
+ *    User-Agent swap is not enough; Referer and Origin are required.
  *
  * Cache: by ISO date at ~/.sunat/cache/tipo-cambio.jsonl (one line per date).
- * SUNAT publishes once per business day; weekend/feriado returns the
- * previous business day's rate (which is the legally-valid TC for those days).
+ * SUNAT publishes once per business day; a date with no published rate
+ * (weekend/feriado) resolves to the previous business day's rate, which is
+ * the legally valid TC for that date.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { paths } from "../data/config.ts";
-import * as browser from "../browser/client.ts";
 
 export interface TipoCambioRate {
 	fecha: string; // YYYY-MM-DD — the date the rate applies to
@@ -24,11 +32,34 @@ export interface TipoCambioRate {
 	venta: number; // S/ per USD (venta)
 	moneda: "USD"; // SUNAT only publishes USD/PEN officially
 	source: "sunat";
-	fetchedAt: string; // ISO timestamp when we scraped
+	fetchedAt: string; // ISO timestamp when we fetched
+	publicada?: string; // YYYY-MM-DD actually published (differs on weekends/feriados)
+}
+
+interface TcRow {
+	fecPublica: string; // DD/MM/YYYY
+	valTipo: string;
+	codTipo: "C" | "V";
 }
 
 const CACHE_FILE = join(paths.sunatDir, "cache", "tipo-cambio.jsonl");
-const SUNAT_TC_URL = "https://e-consulta.sunat.gob.pe/cl-at-ittipcam/tcS01Alias";
+const BASE = "https://e-consulta.sunat.gob.pe/cl-at-ittipcam";
+const TC_PAGE = `${BASE}/tcS01Alias`;
+const TC_ENDPOINT = `${BASE}/tcS01Alias/listarTipoCambio`;
+
+const BROWSER_HEADERS: Record<string, string> = {
+	"User-Agent":
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+	Accept: "application/json, text/javascript, */*; q=0.01",
+	"Accept-Language": "es-ES,es;q=0.9,en;q=0.8",
+	"Content-Type": "application/json; charset=utf-8",
+	"X-Requested-With": "XMLHttpRequest",
+	Referer: TC_PAGE,
+	Origin: "https://e-consulta.sunat.gob.pe",
+	"Sec-Fetch-Dest": "empty",
+	"Sec-Fetch-Mode": "cors",
+	"Sec-Fetch-Site": "same-origin",
+};
 
 function ensureCacheDir(): void {
 	const dir = join(paths.sunatDir, "cache");
@@ -71,38 +102,61 @@ export function saveTc(rate: TipoCambioRate): void {
 	writeFileSync(CACHE_FILE, `${text}\n`);
 }
 
-/**
- * Parse SUNAT's TC table snapshot for a given fecha.
- *
- * The page renders a table with rows like:
- *   "29 Abril 2026 | Compra: 3.760 | Venta: 3.768"
- *
- * The agent-browser snapshot output strips most layout but preserves
- * numbers + day labels. This parser is deliberately tolerant: it scans
- * for the compra/venta pair closest to a "DD MMMM YYYY" date matching
- * the requested fecha (or the most recent if fecha is the weekend).
- */
-export function parseTcSnapshot(snapshot: string, fechaIso: string): { compra: number; venta: number } | null {
-	// Try aria-label style first: "Compra 3.760 Venta 3.768"
-	const ariaMatch = snapshot.match(/Compra[\s:]*([0-9]+\.[0-9]+)[\s\S]{0,40}Venta[\s:]*([0-9]+\.[0-9]+)/i);
-	if (ariaMatch) {
-		return { compra: Number.parseFloat(ariaMatch[1]), venta: Number.parseFloat(ariaMatch[2]) };
-	}
+function toIso(fecPublica: string): string {
+	const [d, m, y] = fecPublica.split("/");
+	return `${y}-${m}-${d}`;
+}
 
-	// Fall back to table cells: split into rows and find any row with two decimals near each other
-	const lines = snapshot.split(/\r?\n/);
-	for (const line of lines) {
-		const m = line.match(/([0-9]+\.[0-9]{2,4})\s*[|\t,;\s]+\s*([0-9]+\.[0-9]{2,4})/);
-		if (m) {
-			const a = Number.parseFloat(m[1]);
-			const b = Number.parseFloat(m[2]);
-			// Sanity: TC values are between 1 and 10 soles per dollar realistically
-			if (a > 1 && a < 10 && b > 1 && b < 10 && Math.abs(a - b) < 0.5) {
-				return { compra: Math.min(a, b), venta: Math.max(a, b) };
-			}
-		}
+/**
+ * Pick the rate for `fechaIso` from a month's rows. SUNAT does not publish on
+ * weekends or holidays; for those dates the valid TC is the last one published
+ * on or before the requested date, so we fall back to it rather than failing.
+ */
+export function selectRateForDate(
+	rows: TcRow[],
+	fechaIso: string,
+): { compra: number; venta: number; publicada: string } | null {
+	const byDate = new Map<string, { compra?: number; venta?: number }>();
+	for (const r of rows) {
+		const iso = toIso(r.fecPublica);
+		const entry = byDate.get(iso) || {};
+		if (r.codTipo === "C") entry.compra = Number.parseFloat(r.valTipo);
+		if (r.codTipo === "V") entry.venta = Number.parseFloat(r.valTipo);
+		byDate.set(iso, entry);
 	}
-	return null;
+	const candidates = [...byDate.keys()].filter((d) => d <= fechaIso).sort();
+	const chosen = candidates[candidates.length - 1];
+	if (!chosen) return null;
+	const v = byDate.get(chosen);
+	if (v?.compra === undefined || v?.venta === undefined) return null;
+	return { compra: v.compra, venta: v.venta, publicada: chosen };
+}
+
+async function fetchMonth(anio: number, mesIndex: number): Promise<TcRow[]> {
+	const res = await fetch(TC_ENDPOINT, {
+		method: "POST",
+		headers: BROWSER_HEADERS,
+		// A non-empty token is required; its contents are not validated.
+		body: JSON.stringify({ anio, mes: mesIndex, token: "x" }),
+	});
+	if (!res.ok) {
+		throw new Error(`SUNAT TC endpoint returned HTTP ${res.status} for ${anio}-${String(mesIndex + 1).padStart(2, "0")}`);
+	}
+	const text = await res.text();
+	if (text.includes("Request Rejected")) {
+		throw new Error("SUNAT WAF rejected the request. Headers may need updating.");
+	}
+	const rows = JSON.parse(text) as TcRow[];
+	// An empty array here is not "no rates published": SUNAT answers 200 with
+	// [] whenever `token` is empty, so treat it as a contract violation rather
+	// than as data. Every real month has rows.
+	if (rows.length === 0) {
+		throw new Error(
+			`SUNAT returned no rows for ${anio}-${String(mesIndex + 1).padStart(2, "0")}. ` +
+				"This usually means the request was rejected rather than that no rate exists.",
+		);
+	}
+	return rows;
 }
 
 export interface FetchTcOpts {
@@ -112,8 +166,8 @@ export interface FetchTcOpts {
 
 /**
  * Public entry point. Returns cached if present (always cacheable, since
- * SUNAT publishes immutable historical TCs). Otherwise opens browser, scrapes,
- * caches, returns.
+ * SUNAT publishes immutable historical TCs). Otherwise queries the month's
+ * endpoint, picks the row for the requested date, caches, returns.
  */
 export async function getTipoCambio(opts: FetchTcOpts = {}): Promise<TipoCambioRate> {
 	const fecha = opts.fecha || new Date().toISOString().split("T")[0];
@@ -123,14 +177,22 @@ export async function getTipoCambio(opts: FetchTcOpts = {}): Promise<TipoCambioR
 		if (cached) return cached;
 	}
 
-	await browser.open(SUNAT_TC_URL, { headed: false });
-	await browser.sleep(2500);
-	const snapshot = await browser.snapshot();
-	const parsed = parseTcSnapshot(snapshot, fecha);
+	const [y, m] = fecha.split("-").map(Number);
+	// SUNAT's `mes` is zero-indexed (JS getMonth()).
+	let rows = await fetchMonth(y, m - 1);
+	let parsed = selectRateForDate(rows, fecha);
+
+	// A date early in the month can fall back to the previous month's last
+	// published rate (e.g. Jan 1st, or a Monday holiday after a long weekend).
 	if (!parsed) {
-		throw new Error(
-			`Could not parse tipo de cambio from SUNAT page for ${fecha}. The portal may have changed layout. Run with --debug to inspect snapshot.`,
-		);
+		const prevY = m === 1 ? y - 1 : y;
+		const prevM = m === 1 ? 12 : m - 1;
+		rows = await fetchMonth(prevY, prevM - 1);
+		parsed = selectRateForDate(rows, fecha);
+	}
+
+	if (!parsed) {
+		throw new Error(`SUNAT published no tipo de cambio on or before ${fecha}.`);
 	}
 
 	const rate: TipoCambioRate = {
@@ -140,6 +202,7 @@ export async function getTipoCambio(opts: FetchTcOpts = {}): Promise<TipoCambioR
 		moneda: "USD",
 		source: "sunat",
 		fetchedAt: new Date().toISOString(),
+		...(parsed.publicada !== fecha ? { publicada: parsed.publicada } : {}),
 	};
 	saveTc(rate);
 	return rate;

--- a/packages/cli/tests/unit/tipo-cambio.test.ts
+++ b/packages/cli/tests/unit/tipo-cambio.test.ts
@@ -2,7 +2,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { loadCachedTc, parseTcSnapshot, saveTc } from "../../src/sunat-rest/tipo-cambio.ts";
+import { loadCachedTc, saveTc, selectRateForDate } from "../../src/sunat-rest/tipo-cambio.ts";
 import { paths } from "../../src/data/config.ts";
 
 const CACHE_FILE = join(paths.sunatDir, "cache", "tipo-cambio.jsonl");
@@ -30,51 +30,53 @@ afterAll(() => {
 	writeFileSync(CACHE_FILE, filtered ? `${filtered}\n` : "");
 });
 
-describe("parseTcSnapshot — pure parser", () => {
-	test("aria-label style 'Compra X Venta Y'", () => {
-		const snap = "Tipo de Cambio Bancario\nCompra 3.760 Venta 3.768\n";
-		const r = parseTcSnapshot(snap, "2026-04-29");
-		expect(r).toEqual({ compra: 3.76, venta: 3.768 });
+const row = (fecPublica: string, valTipo: string, codTipo: "C" | "V") => ({ fecPublica, valTipo, codTipo });
+
+describe("selectRateForDate — pure selector", () => {
+	test("picks the compra/venta pair published on the exact date", () => {
+		const rows = [
+			row("01/11/2025", "3.372", "C"),
+			row("01/11/2025", "3.379", "V"),
+			row("17/11/2025", "3.365", "C"),
+			row("17/11/2025", "3.374", "V"),
+		];
+		expect(selectRateForDate(rows, "2025-11-17")).toEqual({ compra: 3.365, venta: 3.374, publicada: "2025-11-17" });
 	});
 
-	test("aria-label with colons 'Compra: X Venta: Y'", () => {
-		const snap = "Compra: 3.755   Venta: 3.770";
-		const r = parseTcSnapshot(snap, "2026-04-29");
-		expect(r).toEqual({ compra: 3.755, venta: 3.77 });
+	test("falls back to the last rate published before the date", () => {
+		const rows = [
+			row("14/11/2025", "3.360", "C"),
+			row("14/11/2025", "3.370", "V"),
+			row("20/11/2025", "3.400", "C"),
+			row("20/11/2025", "3.410", "V"),
+		];
+		// Nothing published on the 17th: the valid TC is the 14th's.
+		expect(selectRateForDate(rows, "2025-11-17")).toEqual({ compra: 3.36, venta: 3.37, publicada: "2025-11-14" });
 	});
 
-	test("table row '3.760 | 3.768'", () => {
-		const snap = "29 Abril 2026 | 3.760 | 3.768";
-		const r = parseTcSnapshot(snap, "2026-04-29");
-		expect(r).not.toBeNull();
-		expect(r?.compra).toBe(3.76);
-		expect(r?.venta).toBe(3.768);
+	test("never picks a rate published after the requested date", () => {
+		const rows = [row("20/11/2025", "3.400", "C"), row("20/11/2025", "3.410", "V")];
+		expect(selectRateForDate(rows, "2025-11-17")).toBeNull();
 	});
 
-	test("normalizes order so compra <= venta", () => {
-		const snap = "3.770 | 3.755"; // accidentally swapped
-		const r = parseTcSnapshot(snap, "2026-04-29");
-		expect(r?.compra).toBe(3.755);
-		expect(r?.venta).toBe(3.77);
+	test("returns null when a date has compra but no venta", () => {
+		const rows = [row("17/11/2025", "3.365", "C")];
+		expect(selectRateForDate(rows, "2025-11-17")).toBeNull();
 	});
 
-	test("rejects unrelated decimals (e.g. weights, totals)", () => {
-		const snap = "Peso bruto: 100.00 | Peso neto: 99.50";
-		const r = parseTcSnapshot(snap, "2026-04-29");
-		// Sanity check filter: weights are >10 so should be rejected
-		expect(r).toBeNull();
+	test("returns null on empty input", () => {
+		expect(selectRateForDate([], "2025-11-17")).toBeNull();
 	});
 
-	test("returns null on empty/garbage", () => {
-		expect(parseTcSnapshot("", "2026-04-29")).toBeNull();
-		expect(parseTcSnapshot("just text", "2026-04-29")).toBeNull();
-	});
-
-	test("handles 4-decimal values (some TC sources)", () => {
-		const snap = "Compra 3.7625 Venta 3.7700";
-		const r = parseTcSnapshot(snap, "2026-04-29");
-		expect(r?.compra).toBe(3.7625);
-		expect(r?.venta).toBe(3.77);
+	test("orders dates chronologically, not lexically by DD/MM/YYYY", () => {
+		// Lexical sort on "DD/MM/YYYY" would rank 30/11 below 02/12.
+		const rows = [
+			row("30/11/2025", "3.300", "C"),
+			row("30/11/2025", "3.310", "V"),
+			row("02/12/2025", "3.500", "C"),
+			row("02/12/2025", "3.510", "V"),
+		];
+		expect(selectRateForDate(rows, "2025-12-05")?.publicada).toBe("2025-12-02");
 	});
 });
 


### PR DESCRIPTION
`tipo-cambio --fecha` returned today's rate labelled with whatever date you asked for.

The scraper opened `tcS01Alias` with no parameters, parsed the first compra/venta pair on the page, and cached that under the requested date. Only the first call in a run produced a value at all; the rest failed with a message blaming the portal layout and suggesting a `--debug` flag that does not exist.

The damage is quiet: a historical lookup came back with a plausible number that was simply wrong. Asking for 2025-11-17 gave 3.391/3.400, which is August 2026.

## What changed

Query `POST /tcS01Alias/listarTipoCambio` instead, which takes `anio` and a zero-indexed `mes` and returns every published rate for that month, then select the row for the requested date. Dates with no published rate fall back to the last one published before them, crossing into the previous month when needed.

## Two traps in that endpoint

- **`mes` is zero-indexed** (JS `getMonth()`): `mes=10` returns November.
- **An empty `token` yields HTTP 200 with `[]`**, indistinguishable from "no rates published". The first draft of this fix sent `""` and read the empty array as no data, reproducing the very failure mode it was meant to remove. It now sends a non-empty token (the contents are not validated) and treats an empty result as a rejected request.

The WAF also rejects requests without browser-like headers. A User-Agent swap is not enough: `Referer` and `Origin` are required.

## Verification

Eight historical dates return the rates SUNAT publishes, cross-checked against an independent source. Weekend and month-crossing fallbacks exercised. `parseTcSnapshot` is gone, so its tests were replaced with tests for `selectRateForDate`, including one that would catch a lexical sort of `DD/MM/YYYY` ranking 30/11 below 02/12.

345 tests pass.