### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/sunat-cli",
-	"version": "0.7.0",
+	"version": "0.8.0",
 	"description": "Agent-first CLI for SUNAT tax automation",
 	"module": "bin/sunat.ts",
 	"type": "module",


### PR DESCRIPTION
Bumps `packages/cli/package.json`, which is what the release workflow watches. Merging publishes to npm over OIDC, installs the published tarball to check it runs, tags, and opens the GitHub Release.

## What ships

**`f616 declarar`** — file a period by loading income rows into the form. The finding underneath it: the F616 does not need the RHE to exist. The form's own modal validates neither serie nor número against the SEE and puts no cap on how far back the dates go, so the electronic issuer's two-day limit never enters the picture. Eight periods spanning nine months were filed this way on 2026-08-22.

Nothing in it presents or pays. It leaves the form in the tray.

**`skills get core`** — the CLI serves its own docs. The installed agent skill becomes a stub pointing here, so an agent reads the documentation belonging to the version it is running instead of whatever was copied months ago. The previous skill had drifted far enough to tell agents to pass `ingresoPEN` and `retenciones` to `f616 declare`; both are declared in the schema and ignored by the code.

**`tipo-cambio --fecha`** — was returning today's rate labelled with the requested date. Now queries the month endpoint and selects the right row.

## Verification

366 tests pass. The one failure (`styles are inert without a TTY`) predates this and reproduces on `main`.

`npm pack --dry-run` confirms the three `src/skills/*.md` documents are in the tarball; without them `skills get` would ship broken.