### PR TITLE
fix(release): build website from workspace path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Build website
         run: npm run build
-        working-directory: ../website
+        working-directory: packages/website
 
       - name: Build release tarball
         env:


### PR DESCRIPTION
## Summary

Fix the release workflow website build directory. Step-level working directories resolve from the repository root, so `../website` pointed outside the checkout.

## Verification

- `npm run build` passes in `packages/website`
- actionlint passes
- npm remains at 0.8.0; the failed release stopped before tarball construction or publication