### PR TITLE
fix(release): authenticate attestation verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,7 @@ jobs:
       - name: Verify published artifact
         working-directory: .
         env:
+          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.local }}
         run: |
           local_tarball="$GITHUB_WORKSPACE/.release/crafter-sunat-cli-$VERSION.tgz"


### PR DESCRIPTION
## Summary

Pass the workflow GitHub token to `gh attestation verify`.

## Partial-release recovery

The 0.8.1 publish commit succeeded before verification failed. npm now serves 0.8.1 with signature and SLSA provenance. A retry is safe because version detection skips `npm publish`, rebuilds the same 91-file tarball, and continues verification/tag/release.

## Verification

- actionlint passes
- registry tarball SHA-256: `b653800351ea6112579e5e0f800e09c88300655893adcc3c12e58e541ba960f4`
- rebuilt npm 11.6.4 tarball is byte-identical to registry bytes
- `gh attestation verify` succeeds against the publish workflow and source digest