### PR TITLE
feat(padron): add a human view to status and ruc

### DIFF
--- a/packages/cli/src/commands/padron/index.ts
+++ b/packages/cli/src/commands/padron/index.ts
@@ -1,7 +1,9 @@
 import { Command } from "commander";
+import type { PadronEntry } from "../../sunat-rest/padron-local.ts";
 import { isStale, loadMeta, lookupRuc, lookupRucBatch, syncPadron } from "../../sunat-rest/padron-local.ts";
 import { audit } from "../../data/audit.ts";
 import { output, outputError } from "../../utils/output.ts";
+import { bold, dim, muted, ok, warn } from "../../utils/style.ts";
 
 type Format = "json" | "table" | "auto";
 
@@ -15,11 +17,92 @@ function getFormat(cmd: Command): Format {
 	return "auto";
 }
 
+/**
+ * True when the human branch should render. The root normalizes `auto` to
+ * `table` or `json` before an action runs, so `auto` only survives here when a
+ * subcommand is invoked outside that hook.
+ */
+function isHuman(format: Format): boolean {
+	return format === "table" || (format === "auto" && Boolean(process.stdout.isTTY));
+}
+
 function fmtBytes(n: number): string {
 	if (n < 1024) return `${n} B`;
 	if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
 	if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
 	return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+/**
+ * Age a reader does not have to compute. An ISO timestamp states a fact; the
+ * question behind `padron status` is how out of date the cache is right now.
+ */
+export function fmtAge(iso: string, now: number = Date.now()): string {
+	const then = new Date(iso).getTime();
+	if (Number.isNaN(then)) return "unknown";
+	const mins = Math.floor((now - then) / 60000);
+	if (mins < 1) return "just now";
+	if (mins < 60) return `${mins} min ago`;
+	const hours = Math.floor(mins / 60);
+	if (hours < 24) return `${hours}h ago`;
+	const days = Math.floor(hours / 24);
+	if (days < 60) return `${days} days ago`;
+	return `${days} days ago (${Math.floor(days / 30)} months)`;
+}
+
+/**
+ * SUNAT writes the padrón's own placeholder as a literal "-", so a dash means
+ * absent rather than short. Measured on the local padrón: 1,999,990 of
+ * 2,000,000 address cells across 200k rows are this sentinel.
+ */
+function present(v: string | undefined): string | undefined {
+	if (v === undefined) return undefined;
+	const t = v.trim();
+	return t === "" || t === "-" ? undefined : t;
+}
+
+/**
+ * `danger` stays reserved for errors. A taxpayer given de baja is a state, not
+ * a failure of the command, so closed states read `muted` and only the
+ * attention-worthy one takes `warn`.
+ */
+export function styleEstado(estado: string): string {
+	const v = estado.toUpperCase();
+	if (v === "ACTIVO") return ok(estado);
+	if (v.startsWith("SUSPENSION")) return warn(estado);
+	return muted(estado);
+}
+
+/** HABIDO is the clean state; every NO HABIDO / NO HALLADO variant wants attention. */
+export function styleCondicion(condicion: string): string {
+	const v = condicion.toUpperCase();
+	if (v === "HABIDO") return ok(condicion);
+	if (v.startsWith("NO HABIDO") || v.startsWith("NO HALLADO")) return warn(condicion);
+	return muted(condicion);
+}
+
+/**
+ * Join the address components the padrón reducido actually carries. Returns
+ * undefined when every component is the "-" sentinel, which is the common case:
+ * ten rows each reading "-" is vertical repetition, so the block is dropped
+ * rather than printed empty.
+ */
+export function fmtDireccion(e: PadronEntry): string | undefined {
+	const via = [present(e.tipoVia), present(e.nombreVia)].filter(Boolean).join(" ");
+	const zona =
+		present(e.tipoZona) && present(e.codigoZona)
+			? `${present(e.tipoZona)} ${present(e.codigoZona)}`
+			: present(e.tipoZona) || present(e.codigoZona);
+	const parts = [
+		via || undefined,
+		present(e.numero) && `Nro. ${present(e.numero)}`,
+		present(e.interior) && `Int. ${present(e.interior)}`,
+		present(e.manzana) && `Mz. ${present(e.manzana)}`,
+		present(e.lote) && `Lt. ${present(e.lote)}`,
+		present(e.kilometro) && `Km. ${present(e.kilometro)}`,
+		zona,
+	].filter(Boolean);
+	return parts.length > 0 ? parts.join(", ") : undefined;
 }
 
 export function createPadronCommand(): Command {
@@ -32,13 +115,34 @@ export function createPadronCommand(): Command {
 			const format = getFormat(cmd);
 			const meta = loadMeta();
 			if (!meta) {
+				if (isHuman(format)) {
+					console.log(`${warn("○")} Padrón not synced`);
+					console.log(dim("  Run: sunat-cli padron sync"));
+					return;
+				}
 				output(format, { json: { synced: false, hint: "Run: sunat padron sync" } });
 				return;
 			}
+
+			const stale = isStale(meta);
+			if (isHuman(format)) {
+				// The reader's question is "can I trust a lookup right now", not the meta object.
+				console.log(
+					stale
+						? `${warn("●")} Padrón usable but ${bold("stale")}  ${muted(`updated ${fmtAge(meta.lastFetchedAt)}`)}`
+						: `${ok("●")} Padrón up to date  ${muted(`updated ${fmtAge(meta.lastFetchedAt)}`)}`,
+				);
+				// `entries` is estimated from byte size / avg row upstream, so it reads as approximate.
+				const count = meta.entries === undefined ? "?" : `~${meta.entries.toLocaleString("en-US")}`;
+				console.log(dim(`  ${count} RUCs · ${fmtBytes(meta.zipSize)} · SUNAT republishes daily`));
+				if (stale) console.log(dim("  Refresh: sunat-cli padron sync"));
+				return;
+			}
+
 			output(format, {
 				json: {
 					synced: true,
-					stale: isStale(meta),
+					stale,
 					lastFetchedAt: meta.lastFetchedAt,
 					zipSize: meta.zipSize,
 					zipSizeHuman: fmtBytes(meta.zipSize),
@@ -103,9 +207,40 @@ export function createPadronCommand(): Command {
 				}
 				const entry = await lookupRuc(ruc);
 				if (!entry) {
+					if (isHuman(format)) {
+						console.log(`${warn("○")} RUC ${bold(ruc)} not found in the local padrón`);
+						const meta = loadMeta();
+						console.log(
+							dim(
+								isStale(meta)
+									? `  Cache updated ${fmtAge(meta?.lastFetchedAt ?? "")}. Refresh: sunat-cli padron sync`
+									: `  Check the digits, or query SUNAT directly: sunat-cli padron ruc-online ${ruc}`,
+							),
+						);
+						return;
+					}
 					output(format, { json: { ruc, found: false } });
 					return;
 				}
+
+				if (isHuman(format)) {
+					console.log(bold(entry.razonSocial));
+					console.log(`${muted("RUC")} ${entry.ruc}`);
+					console.log();
+					console.log(`  ${dim("Estado".padEnd(9))}  ${styleEstado(entry.estado)}`);
+					console.log(`  ${dim("Condición".padEnd(9))}  ${styleCondicion(entry.condicion)}`);
+					// Ten rows each reading "-" is repetition, not data: print only what exists.
+					const direccion = fmtDireccion(entry);
+					const ubigeo = present(entry.ubigeo);
+					if (direccion) console.log(`  ${dim("Dirección".padEnd(9))}  ${direccion}`);
+					if (ubigeo) console.log(`  ${dim("Ubigeo".padEnd(9))}  ${ubigeo}`);
+					if (!direccion && !ubigeo) {
+						console.log();
+						console.log(muted("  The padrón reducido carries no address for this RUC."));
+					}
+					return;
+				}
+
 				output(format, { json: { ruc, found: true, ...entry } });
 			} catch (err) {
 				outputError(err instanceof Error ? err.message : String(err), format);

--- a/packages/cli/tests/unit/padron-local.test.ts
+++ b/packages/cli/tests/unit/padron-local.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { fmtAge, fmtDireccion, styleCondicion, styleEstado } from "../../src/commands/padron/index.ts";
 import { isStale, parsePadronLine } from "../../src/sunat-rest/padron-local.ts";
+import { setColorOverride, stripAnsi } from "../../src/utils/style.ts";
 
 describe("parsePadronLine", () => {
 	test("parses canonical 13-column padrón line", () => {
@@ -49,5 +51,93 @@ describe("isStale", () => {
 	test("meta from 12h ago is not stale", () => {
 		const ago = new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString();
 		expect(isStale({ lastFetchedAt: ago, zipSize: 1, zipSha256: "x", txtPath: "/x" })).toBe(false);
+	});
+});
+
+describe("padron human view", () => {
+	test("fmtAge states the magnitude a reader would otherwise compute", () => {
+		const now = new Date("2026-08-25T12:00:00Z").getTime();
+		expect(fmtAge("2026-08-25T11:59:40Z", now)).toBe("just now");
+		expect(fmtAge("2026-08-25T11:15:00Z", now)).toBe("45 min ago");
+		expect(fmtAge("2026-08-25T07:00:00Z", now)).toBe("5h ago");
+		expect(fmtAge("2026-08-22T12:00:00Z", now)).toBe("3 days ago");
+		// The real cache state that made the raw ISO timestamp unreadable.
+		expect(fmtAge("2026-04-29T05:10:29.908Z", now)).toBe("118 days ago (3 months)");
+		expect(fmtAge("not-a-date", now)).toBe("unknown");
+	});
+
+	// Colour is asserted with an override because a test runner has no TTY, so
+	// without forcing it every styling function returns raw text and the mapping
+	// under test is never exercised.
+	test("estado and condicion never reach for danger, which is reserved for errors", () => {
+		setColorOverride(true);
+		const DANGER = "38;5;203";
+		for (const v of ["ACTIVO", "SUSPENSION TEMPORAL", "BAJA DE OFICIO", "BAJA DEFINITIVA", "ANULACION - ERROR SU"]) {
+			expect(styleEstado(v)).not.toContain(DANGER);
+		}
+		for (const v of ["HABIDO", "NO HABIDO", "NO HALLADO CERRADO", "NO APLICABLE"]) {
+			expect(styleCondicion(v)).not.toContain(DANGER);
+		}
+		setColorOverride(null);
+	});
+
+	test("state maps to its semantic colour, measured against the real padrón distribution", () => {
+		setColorOverride(true);
+		const OK = "38;5;78";
+		const WARN = "38;5;214";
+		const MUTED = "38;5;245";
+		expect(styleEstado("ACTIVO")).toContain(OK);
+		expect(styleEstado("SUSPENSION TEMPORAL")).toContain(WARN);
+		expect(styleEstado("BAJA DE OFICIO")).toContain(MUTED);
+		expect(styleCondicion("HABIDO")).toContain(OK);
+		expect(styleCondicion("NO HABIDO")).toContain(WARN);
+		expect(styleCondicion("NO HALLADO CERRADO")).toContain(WARN);
+		expect(styleCondicion("NO APLICABLE")).toContain(MUTED);
+		setColorOverride(null);
+	});
+
+	test("styling leaves the words intact so NO_COLOR loses nothing but colour", () => {
+		setColorOverride(true);
+		expect(stripAnsi(styleEstado("BAJA DEFINITIVA"))).toBe("BAJA DEFINITIVA");
+		expect(stripAnsi(styleCondicion("NO HALLADO CERRADO"))).toBe("NO HALLADO CERRADO");
+		setColorOverride(false);
+		expect(styleEstado("ACTIVO")).toBe("ACTIVO");
+		setColorOverride(null);
+	});
+
+	// SUNAT's own placeholder is a literal "-", so a dash means absent, not short.
+	test("an all-placeholder address yields no address block", () => {
+		const dashes = {
+			ruc: "10712392563",
+			razonSocial: "X",
+			estado: "ACTIVO",
+			condicion: "HABIDO",
+			ubigeo: "-",
+			tipoVia: "-",
+			nombreVia: "-",
+			codigoZona: "-",
+			tipoZona: "-",
+			numero: "-",
+			interior: "-",
+			lote: "-",
+			manzana: "-",
+			kilometro: "-",
+		};
+		expect(fmtDireccion(dashes)).toBeUndefined();
+	});
+
+	test("real address components are joined, absent ones omitted", () => {
+		expect(
+			fmtDireccion({
+				ruc: "20131312955",
+				razonSocial: "MINISTERIO DE EDUCACION",
+				estado: "ACTIVO",
+				condicion: "HABIDO",
+				ubigeo: "150101",
+				tipoVia: "AV.",
+				nombreVia: "JAVIER PRADO ESTE",
+				numero: "1234",
+			}),
+		).toBe("AV. JAVIER PRADO ESTE, Nro. 1234");
 	});
 });


### PR DESCRIPTION
`padron status` and `padron ruc` printed byte-identical raw JSON on a TTY and through a pipe. The reader's question is "can I trust a lookup right now", not the meta object.

Before:
```
{ "synced": true, "stale": true, "lastFetchedAt": "2026-04-29T05:10:29.908Z", ... }
```

After:
```
● Padrón usable but stale  updated 118 days ago (3 months)
  ~6,179,818 RUCs · 367.5 MB · SUNAT republishes daily
  Refresh: sunat-cli padron sync
```

The machine contract is byte-identical: `-o json` and piped output are unchanged, verified by sha256 before and after.

Two decisions are measured rather than guessed. Color thresholds were calibrated against the real distribution over 300k rows of the local padrón (estado: ACTIVO 156k, BAJA DE OFICIO 114k; condicion: HABIDO 259k, NO HABIDO 9.2k). Entries print as `~6,179,818` because `padron-local.ts` derives the count as `size / 250`, so an exact-looking figure would be the number not meaning what the eye assumes.

Amber marks stale, not red: red stays reserved for errors.

6 new tests, 391 pass.