### PR TITLE
feat(cli): emit nextSteps so an agent knows what to run next

### DIFF
--- a/packages/cli/skills/sunat-cli/SKILL.md
+++ b/packages/cli/skills/sunat-cli/SKILL.md
@@ -489,6 +489,31 @@ All commands support `--output <format>`:
 - `auto` (default): human-readable
 - `json`: machine-readable, pipe to `jq`
 
+**stdout is data, stderr is everything else.** Errors and next-step hints go to
+stderr, so `cmd --output json > out.json` writes only the result.
+
+### Next steps
+
+Some commands name what to run next. In `--output json` these arrive on stderr
+as NDJSON, one object per line, tagged `"type": "next-step"`:
+
+```json
+{"type":"next-step","command":"sunat-cli renta constancia 68378d1065fb17631760eca0","description":"proof of filing for the most recent one"}
+```
+
+Fields: `command` (runnable as printed, values already substituted),
+`description`, and `optional` when the step is a suggestion rather than the
+expected continuation. Read stdout for data and stderr for hints:
+
+```bash
+sunat-cli renta presentaciones -e 2024 --output json 2>steps.ndjson >filings.ndjson
+```
+
+Commands that emit them today: `whoami`, `padron status` (when stale),
+`skills list`, `renta whoami`, `renta status`, `renta presentaciones`.
+The list is additive; treat an absent hint as "no unambiguous next step",
+not as an error.
+
 ## Common Workflows
 
 **Monthly routine (4ta categoria)**:

--- a/packages/cli/src/commands/padron/index.ts
+++ b/packages/cli/src/commands/padron/index.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { isStale, loadMeta, lookupRuc, lookupRucBatch, syncPadron } from "../../sunat-rest/padron-local.ts";
 import { audit } from "../../data/audit.ts";
+import { emitNextSteps } from "../../utils/next-steps.ts";
 import { output, outputError } from "../../utils/output.ts";
 
 type Format = "json" | "table" | "auto";
@@ -33,12 +34,17 @@ export function createPadronCommand(): Command {
 			const meta = loadMeta();
 			if (!meta) {
 				output(format, { json: { synced: false, hint: "Run: sunat padron sync" } });
+				emitNextSteps(
+					[{ command: "sunat-cli padron sync", description: "download the padrón for the first time" }],
+					format,
+				);
 				return;
 			}
+			const stale = isStale(meta);
 			output(format, {
 				json: {
 					synced: true,
-					stale: isStale(meta),
+					stale,
 					lastFetchedAt: meta.lastFetchedAt,
 					zipSize: meta.zipSize,
 					zipSizeHuman: fmtBytes(meta.zipSize),
@@ -46,6 +52,10 @@ export function createPadronCommand(): Command {
 					sha256: `${meta.zipSha256.slice(0, 16)}...`,
 				},
 			});
+			emitNextSteps(
+				stale ? [{ command: "sunat-cli padron sync", description: "the local copy is out of date" }] : [],
+				format,
+			);
 		});
 
 	padron

--- a/packages/cli/src/commands/renta/index.ts
+++ b/packages/cli/src/commands/renta/index.ts
@@ -14,6 +14,7 @@ import {
 } from "../../renta/f709-api.ts";
 import { ensureRentaToken, loginRenta } from "../../renta/login.ts";
 import { hasFreshToken, readToken } from "../../renta/session.ts";
+import { emitNextSteps, type NextStep } from "../../utils/next-steps.ts";
 import { output, outputError, outputSuccess } from "../../utils/output.ts";
 import { bold, dim, info, muted, ok, warn } from "../../utils/style.ts";
 
@@ -97,17 +98,28 @@ export function createRentaCommand(): Command {
 				versionWeb: cached?.versionWeb ?? null,
 			};
 
+			const steps: NextStep[] = fresh
+				? [
+						{
+							command: `sunat-cli renta presentaciones -e ${defaultEjercicio()}`,
+							description: "declarations already filed",
+						},
+					]
+				: [{ command: "sunat-cli renta login", description: "sign in to e-renta" }];
+
 			if (format === "json") {
 				output(format, { json });
+				emitNextSteps(steps, format);
 				return;
 			}
 			if (!fresh) {
 				console.log(`${warn("○")} No active e-renta session`);
-				console.log(dim("  Run: sunat-cli renta login"));
+				emitNextSteps(steps, format);
 				return;
 			}
 			console.log(`${ok("●")} Session active${ruc ? ` for ${bold(ruc)}` : ""}`);
 			console.log(dim(`  expires in ${mins} min · client ${cached?.versionWeb}`));
+			emitNextSteps(steps, format);
 		});
 
 	renta
@@ -234,13 +246,29 @@ export function createRentaCommand(): Command {
 				const ruc = getCredentials().ruc;
 				const items = await listarPresentaciones(ruc, opts.ejercicio);
 
+				const steps: NextStep[] = items.length
+					? [
+							{
+								command: `sunat-cli renta constancia ${items[0].idPresentacion}`,
+								description: "proof of filing for the most recent one",
+							},
+						]
+					: [
+							{
+								command: `sunat-cli renta form -e ${opts.ejercicio}`,
+								description: "check the form is available for this ejercicio",
+							},
+						];
+
 				if (format === "json") {
 					output(format, { json: items });
+					emitNextSteps(steps, format);
 					return;
 				}
 
 				if (items.length === 0) {
 					console.log(`${warn("○")} No filings for ejercicio ${bold(opts.ejercicio)}`);
+					emitNextSteps(steps, format);
 					return;
 				}
 
@@ -261,8 +289,7 @@ export function createRentaCommand(): Command {
 						]),
 					},
 				});
-				console.log();
-				console.log(dim(`Constancia:  sunat-cli renta constancia ${items[0].idPresentacion}`));
+				emitNextSteps(steps, format);
 			} catch (err) {
 				fail(err, format);
 			}
@@ -311,11 +338,19 @@ export function createRentaCommand(): Command {
 			try {
 				await ensureRentaToken();
 				const t = await obtenerFechaHora();
+				const steps: NextStep[] = [
+					{
+						command: `sunat-cli renta presentaciones -e ${defaultEjercicio()}`,
+						description: "declarations already filed",
+					},
+				];
 				if (format === "json") {
 					output(format, { json: { up: true, ...t } });
+					emitNextSteps(steps, format);
 					return;
 				}
 				console.log(`${ok("●")} e-renta responding  ${muted(`server date ${t.fecha}`)}`);
+				emitNextSteps(steps, format);
 			} catch (err) {
 				fail(err, format);
 			}

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { existsSync, readFileSync, readdirSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
+import { emitNextSteps } from "../utils/next-steps.ts";
 import { output, outputError } from "../utils/output.ts";
 
 /**
@@ -61,8 +62,20 @@ export function createSkillsCommand(): Command {
 		.description("What documentation this version ships")
 		.action(() => {
 			const items = listar();
-			if (quiereJson()) { output("json", { json: { skills: items } }); return; }
-			for (const s of items) console.log(`  ${s.name.padEnd(12)} ${s.summary}`);
+			const json = quiereJson();
+			if (json) {
+				output("json", { json: { skills: items } });
+			} else {
+				for (const s of items) console.log(`  ${s.name.padEnd(12)} ${s.summary}`);
+			}
+			emitNextSteps(
+				items.map((s) =>
+					s.name === "core"
+						? { command: "sunat-cli skills get core", description: "the usage guide" }
+						: { command: `sunat-cli skills get ${s.name}`, description: `read ${s.name}`, optional: true },
+				),
+				json ? "json" : "table",
+			);
 		});
 
 	skills

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -1,6 +1,7 @@
 import { existsSync, statSync } from "node:fs";
 import { Command } from "commander";
 import { loadConfig, paths } from "../data/config.ts";
+import { emitNextSteps, type NextStep } from "../utils/next-steps.ts";
 import { output } from "../utils/output.ts";
 
 export function createWhoamiCommand(): Command {
@@ -33,6 +34,13 @@ export function createWhoamiCommand(): Command {
 			},
 		};
 
+		const steps: NextStep[] = [];
+		if (!data.ruc || !data.usuario) {
+			steps.push({ command: "sunat-cli login", description: "set RUC and usuario, then sign in" });
+		} else if (data.sessions.sol.stale) {
+			steps.push({ command: "sunat-cli login", description: "the SOL session is stale" });
+		}
+
 		output(format, {
 			json: data,
 			table: {
@@ -49,5 +57,7 @@ export function createWhoamiCommand(): Command {
 				],
 			},
 		});
+
+		emitNextSteps(steps, format);
 	});
 }

--- a/packages/cli/src/utils/next-steps.ts
+++ b/packages/cli/src/utils/next-steps.ts
@@ -1,0 +1,54 @@
+import type { OutputFormat } from "./output.ts";
+import { bold, dim, info, muted } from "./style.ts";
+
+/**
+ * What the caller can run next, emitted after a command succeeds.
+ *
+ * Two constraints decided the channel, and both point at stderr:
+ *
+ * 1. stdout is the published machine contract. Several commands emit an array
+ *    (`renta presentaciones`, `renta casillas`), which `output` writes as
+ *    NDJSON, and an array has nowhere to put a new key. Anything added to
+ *    stdout would either change a shape agents already parse or be impossible.
+ * 2. Data on stdout, diagnostics on stderr, the same split `outputError`
+ *    already makes. A caller doing `cmd > out.json` must not find guidance in
+ *    the file it is about to parse.
+ *
+ * So this is purely additive: every existing byte on stdout is unchanged, and
+ * a consumer that ignores stderr sees exactly what it saw before.
+ *
+ * Field names match the cligentic `agent/next-steps` block, which this repo
+ * deliberately does not depend on, so the shape is not a third dialect.
+ */
+export type NextStep = {
+	/** The literal command to run, with real values already substituted. */
+	command: string;
+	/** Short reason the step matters. */
+	description: string;
+	/** Suggested rather than expected. */
+	optional?: boolean;
+};
+
+/**
+ * Never throws and never exits: guidance must not be able to fail a command
+ * that already succeeded.
+ */
+export function emitNextSteps(steps: NextStep[], format: OutputFormat): void {
+	if (steps.length === 0) return;
+
+	const resolved = format === "auto" ? (process.stdout.isTTY ? "table" : "json") : format;
+
+	if (resolved === "json") {
+		for (const step of steps) {
+			process.stderr.write(`${JSON.stringify({ type: "next-step", ...step })}\n`);
+		}
+		return;
+	}
+
+	process.stderr.write(`\n${bold("Next steps:")}\n`);
+	for (const step of steps) {
+		const marker = step.optional ? muted("○") : info("→");
+		process.stderr.write(`  ${marker} ${step.command}  ${dim(step.description)}\n`);
+	}
+	process.stderr.write("\n");
+}

--- a/packages/cli/tests/unit/next-steps.test.ts
+++ b/packages/cli/tests/unit/next-steps.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { emitNextSteps } from "../../src/utils/next-steps.ts";
+import { setColorOverride } from "../../src/utils/style.ts";
+
+const realWrite = process.stderr.write.bind(process.stderr);
+
+function captureStderr(fn: () => void): string {
+	let buf = "";
+	// @ts-expect-error narrowing the overloads of stderr.write is not worth it here
+	process.stderr.write = (chunk: string) => {
+		buf += chunk;
+		return true;
+	};
+	try {
+		fn();
+	} finally {
+		process.stderr.write = realWrite;
+	}
+	return buf;
+}
+
+afterEach(() => {
+	setColorOverride(null);
+});
+
+describe("emitNextSteps", () => {
+	test("emits nothing for an empty list", () => {
+		expect(captureStderr(() => emitNextSteps([], "json"))).toBe("");
+		expect(captureStderr(() => emitNextSteps([], "table"))).toBe("");
+	});
+
+	test("json mode writes one NDJSON object per step, tagged for agents", () => {
+		const out = captureStderr(() =>
+			emitNextSteps(
+				[
+					{ command: "sunat-cli renta constancia abc123", description: "proof of filing" },
+					{ command: "sunat-cli skills get schemas", description: "field specs", optional: true },
+				],
+				"json",
+			),
+		);
+		const lines = out.trim().split("\n");
+		expect(lines).toHaveLength(2);
+		expect(JSON.parse(lines[0])).toEqual({
+			type: "next-step",
+			command: "sunat-cli renta constancia abc123",
+			description: "proof of filing",
+		});
+		expect(JSON.parse(lines[1])).toEqual({
+			type: "next-step",
+			command: "sunat-cli skills get schemas",
+			description: "field specs",
+			optional: true,
+		});
+	});
+
+	test("json mode carries no ANSI escapes even when colour is forced on", () => {
+		setColorOverride(true);
+		const out = captureStderr(() =>
+			emitNextSteps([{ command: "sunat-cli padron sync", description: "cache is stale" }], "json"),
+		);
+		expect(out).not.toContain("\x1b[");
+	});
+
+	test("human mode names the command and marks optional steps differently", () => {
+		setColorOverride(false);
+		const out = captureStderr(() =>
+			emitNextSteps(
+				[
+					{ command: "sunat-cli login", description: "sign in" },
+					{ command: "sunat-cli whoami", description: "check auth", optional: true },
+				],
+				"table",
+			),
+		);
+		expect(out).toContain("Next steps:");
+		expect(out).toContain("→ sunat-cli login");
+		expect(out).toContain("○ sunat-cli whoami");
+	});
+
+	test("every emitted command names the installed bin, not a bare 'sunat'", () => {
+		setColorOverride(false);
+		const out = captureStderr(() =>
+			emitNextSteps([{ command: "sunat-cli renta status", description: "service health" }], "table"),
+		);
+		expect(out).toMatch(/sunat-cli renta status/);
+		expect(out).not.toMatch(/(^|[^-\w])sunat renta/);
+	});
+});


### PR DESCRIPTION
No command told an agent what it could run next. The CLI has genuinely sequential workflows (login, then a period, then rows, then the tray) and each step's output is the natural place to name the next one.

Steps go to **stderr**, not stdout. Two reasons, the second decisive: `output()` emits NDJSON when the payload is an array, and `renta presentaciones`/`renta casillas` return arrays. An array has nowhere to put a new key, so the additive path is the only one available. Every existing stdout byte is unchanged.

The shape matches cligentic's `agent/next-steps` block (`command`, `description`, `optional?`; NDJSON tagged `type: "next-step"`; never throws, never exits) reimplemented in-repo with no new dependency.

Covers 6 of 80 commands, chosen because a next step genuinely exists and is unambiguous: `whoami`, `padron status` when stale, `skills list`, `renta whoami`, `renta status`, `renta presentaciones`. Write-path commands are deliberately excluded, since an emitted command is an executable promise and those cannot be verified without filing something.

Every emitted read-only string was copied and run verbatim.

5 new tests, 390 pass. The suite was mutation-tested: moving the write to stdout makes it fail.