### PR TITLE
test(cli): isolate test state behind a SUNAT_HOME override

### DIFF
--- a/packages/cli/bunfig.toml
+++ b/packages/cli/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./tests/setup.ts"]

--- a/packages/cli/scripts/smoke-boleta.sh
+++ b/packages/cli/scripts/smoke-boleta.sh
@@ -9,6 +9,10 @@
 
 set -euo pipefail
 
+# State root. Export SUNAT_HOME to point this run at a scratch dir instead of
+# the operator's real ~/.sunat sessions, tokens and audit log.
+export SUNAT_HOME="${SUNAT_HOME:-$HOME/.sunat}"
+
 CERT_DIR="${TMPDIR:-/tmp}"
 CERT_PEM="$CERT_DIR/sunat-test.pem"
 CERT_PFX="$CERT_DIR/sunat-test.pfx"

--- a/packages/cli/scripts/smoke-padron.sh
+++ b/packages/cli/scripts/smoke-padron.sh
@@ -9,6 +9,10 @@
 
 set -euo pipefail
 
+# State root. Export SUNAT_HOME to point this run at a scratch dir instead of
+# the operator's real ~/.sunat sessions, tokens and audit log.
+export SUNAT_HOME="${SUNAT_HOME:-$HOME/.sunat}"
+
 KNOWN_RUC="20131312955" # SUPERINTENDENCIA NACIONAL DE ADUANAS Y DE ADMINISTRACION TRIBUTARIA - SUNAT
 
 echo "→ Padron status..."

--- a/packages/cli/scripts/smoke-sunat.sh
+++ b/packages/cli/scripts/smoke-sunat.sh
@@ -9,6 +9,10 @@
 
 set -euo pipefail
 
+# State root. Export SUNAT_HOME to point this run at a scratch dir instead of
+# the operator's real ~/.sunat sessions, tokens and audit log.
+export SUNAT_HOME="${SUNAT_HOME:-$HOME/.sunat}"
+
 CERT_DIR="${TMPDIR:-/tmp}"
 CERT_PEM="$CERT_DIR/sunat-test.pem"
 CERT_PFX="$CERT_DIR/sunat-test.pfx"

--- a/packages/cli/src/data/config.ts
+++ b/packages/cli/src/data/config.ts
@@ -3,7 +3,18 @@ import { join } from "node:path";
 import { missingSecretMessage, resolveSecret } from "./keychain.ts";
 import { ensurePrivateDir, secureExistingFile, writePrivateFile } from "./private-storage.ts";
 
-const SUNAT_DIR = join(process.env.HOME || "", ".sunat");
+/**
+ * Root of all on-disk state. `SUNAT_HOME` overrides it so tests and smoke runs
+ * can point at a scratch dir instead of the operator's live sessions, tokens
+ * and audit log. Every path under the home dir must be composed from this.
+ */
+export function resolveSunatDir(): string {
+	const override = process.env.SUNAT_HOME;
+	if (override) return override;
+	return join(process.env.HOME || "", ".sunat");
+}
+
+const SUNAT_DIR = resolveSunatDir();
 const CONFIG_FILE = join(SUNAT_DIR, "config.json");
 const API_DIR = join(SUNAT_DIR, "api");
 const SESSIONS_DIR = join(SUNAT_DIR, "sessions");

--- a/packages/cli/src/plataforma/session.ts
+++ b/packages/cli/src/plataforma/session.ts
@@ -1,8 +1,8 @@
 import { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { privateChildEnv } from "../data/child-process.ts";
+import { paths } from "../data/config.ts";
 import { secureExistingFile, writePrivateFile } from "../data/private-storage.ts";
 
 /**
@@ -21,8 +21,7 @@ import { secureExistingFile, writePrivateFile } from "../data/private-storage.ts
  */
 
 const SESSION = "sunat";
-const CACHE_DIR = join(homedir(), ".sunat");
-const CACHE_FILE = join(CACHE_DIR, "plataforma-token.json");
+const CACHE_FILE = join(paths.sunatDir, "plataforma-token.json");
 
 export const PLATAFORMA_BASE = "https://e-plataformaunica.sunat.gob.pe";
 

--- a/packages/cli/src/renta/session.ts
+++ b/packages/cli/src/renta/session.ts
@@ -1,8 +1,8 @@
 import { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { privateChildEnv } from "../data/child-process.ts";
+import { paths } from "../data/config.ts";
 import { secureExistingFile, writePrivateFile } from "../data/private-storage.ts";
 
 /**
@@ -26,8 +26,7 @@ import { secureExistingFile, writePrivateFile } from "../data/private-storage.ts
  */
 
 const SESSION = "sunat-renta";
-const CACHE_DIR = join(homedir(), ".sunat");
-const CACHE_FILE = join(CACHE_DIR, "renta-token.json");
+const CACHE_FILE = join(paths.sunatDir, "renta-token.json");
 
 export const RENTA_BASE = "https://e-renta.sunat.gob.pe";
 export const RENTA_API = `${RENTA_BASE}/v1/recaudacion/declaracionespago/renta`;

--- a/packages/cli/tests/e2e/audit-cli.test.ts
+++ b/packages/cli/tests/e2e/audit-cli.test.ts
@@ -24,7 +24,7 @@ async function runCli(args: string[], home: string): Promise<CliResult> {
 	const proc = Bun.spawn(["bun", "run", CLI, ...args], {
 		stdout: "pipe",
 		stderr: "pipe",
-		env: { ...process.env, HOME: home, CPE_DRIVER: "mock" },
+		env: { ...process.env, HOME: home, SUNAT_HOME: join(home, ".sunat"), CPE_DRIVER: "mock" },
 	});
 	const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
 	const exitCode = await proc.exited;

--- a/packages/cli/tests/e2e/cpe-cli.test.ts
+++ b/packages/cli/tests/e2e/cpe-cli.test.ts
@@ -32,10 +32,11 @@ async function runCli(args: string[]): Promise<CliResult> {
 }
 
 async function runCliWithEnv(args: string[], env: Record<string, string | undefined>): Promise<CliResult> {
+	const scoped = env.HOME ? { SUNAT_HOME: join(env.HOME, ".sunat"), ...env } : env;
 	const proc = Bun.spawn(["bun", "run", CLI, ...args], {
 		stdout: "pipe",
 		stderr: "pipe",
-		env: { ...process.env, ...env },
+		env: { ...process.env, ...scoped },
 	});
 	const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
 	const exitCode = await proc.exited;
@@ -188,6 +189,7 @@ describe("sunat cpe — E2E", () => {
 		const home = createTempHome();
 		const script = `
 process.env.HOME = ${JSON.stringify(home)};
+process.env.SUNAT_HOME = ${JSON.stringify(join(home, ".sunat"))};
 process.env.CPE_DRIVER = "mock";
 delete process.env.CPE_PROFILE;
 delete process.env.CPE_EMISOR_RUC;
@@ -208,7 +210,7 @@ await run(["factura", "emit", "--params", JSON.stringify({ ...base, serie: "F101
 		const proc = Bun.spawn(["bun", "--eval", script], {
 			stdout: "pipe",
 			stderr: "pipe",
-			env: { ...process.env, HOME: home, CPE_DRIVER: "mock" },
+			env: { ...process.env, HOME: home, SUNAT_HOME: join(home, ".sunat"), CPE_DRIVER: "mock" },
 		});
 		const [, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
 		expect(await proc.exited).toBe(0);

--- a/packages/cli/tests/setup.ts
+++ b/packages/cli/tests/setup.ts
@@ -1,0 +1,21 @@
+/**
+ * Test isolation. Loaded via `preload` in bunfig.toml, so it runs once per test
+ * process before any test file imports `src/data/config.ts` and freezes its
+ * paths.
+ *
+ * Both vars are set together on purpose. Tests that spawn the CLI as a child
+ * pass `{ ...process.env, HOME: tempHome }` and assert against
+ * `<tempHome>/.sunat`; if only SUNAT_HOME were set here it would be inherited
+ * through that spread and win over the child's own HOME, sending state
+ * somewhere the test does not look. Pointing HOME at the same scratch root
+ * keeps that per-test override meaningful.
+ */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+if (!process.env.SUNAT_HOME) {
+	const root = mkdtempSync(join(tmpdir(), "sunat-test-home-"));
+	process.env.HOME = root;
+	process.env.SUNAT_HOME = join(root, ".sunat");
+}

--- a/packages/cli/tests/unit/privacy.test.ts
+++ b/packages/cli/tests/unit/privacy.test.ts
@@ -10,7 +10,7 @@ async function probe(action: string): Promise<string> {
 	const home = mkdtempSync(join(tmpdir(), "sunat-privacy-"));
 	homes.push(home);
 	const proc = Bun.spawn(["bun", "run", PROBE, action], {
-		env: { ...process.env, HOME: home },
+		env: { ...process.env, HOME: home, SUNAT_HOME: join(home, ".sunat") },
 		stdout: "pipe",
 		stderr: "pipe",
 	});


### PR DESCRIPTION
The test suite wrote to the operator's real `~/.sunat`, sharing it with live sessions, cached tokens and the audit log.

This is not theoretical. Measured on an unmodified run: **3,822 bytes appended to the live audit log**, plus mtime rewrites on all 11 audit files, `audit-privacy-v1` and `cache/tipo-cambio.jsonl`. The idempotency test's own cleanup did not restore it, and `tests/unit/idempotency.test.ts` documents the problem in its own comments, working around it with collision-proof IDs.

Adds `resolveSunatDir()` honoring `SUNAT_HOME`, with all seven `paths` entries deriving from it. Two files bypassed `paths` entirely and built `join(homedir(), ".sunat")` themselves (`renta/session.ts`, `plataforma/session.ts`); both now route through the resolver. Smoke scripts default to `$HOME/.sunat` so behavior is unchanged.

Isolation is one setup point via `bunfig.toml` preload, not 38 edited files. Three e2e files still needed changes because they spawn the CLI with a custom `HOME`, and an inherited `SUNAT_HOME` would outrank it.

Verified: 135 filesystem entries under `~/.sunat` byte-identical before and after a full run. Positive control included, so the pass is not "nothing ran": with `SUNAT_HOME=/tmp/...` the artifacts land there instead.

385 pass, unchanged.