### PR TITLE
feat(schema): version the contract

### DIFF
--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -17,44 +17,66 @@ const AVAILABLE_SCHEMAS = [
 	"cpe-catalogos",
 ] as const;
 
+type SchemaName = (typeof AVAILABLE_SCHEMAS)[number];
+
+// Contract version per resource, independent of the package version: it moves
+// only when the described contract changes, so an agent diffing it does not
+// see churn from unrelated releases. Bump on any field, flag or shape change.
+const SCHEMA_VERSIONS: Record<SchemaName, string> = {
+	rhe: "1.0.0",
+	f616: "1.0.0",
+	renta: "1.0.0",
+	login: "1.0.0",
+	"cpe-factura": "1.0.0",
+	"cpe-boleta": "1.0.0",
+	"cpe-nota-credito": "1.0.0",
+	"cpe-catalogos": "1.0.0",
+};
+
+function withVersion(resource: SchemaName, schema: Record<string, unknown>): Record<string, unknown> {
+	return { version: schema.version ?? SCHEMA_VERSIONS[resource], ...schema };
+}
+
 export function createSchemaCommand(): Command {
 	return new Command("schema")
 		.description("Introspect command schemas (agent self-service)")
 		.argument("<resource>", `Resource to describe: ${AVAILABLE_SCHEMAS.join(", ")}`)
 		.action((resource: string) => {
 			if (resource === "login") {
-				outputJSON({
-					command: "login",
-					description: "Authenticate with SUNAT Clave SOL",
-					auth: {
-						envVars: {
-							SUNAT_RUC: "RUC number (11 digits)",
-							SUNAT_USER: "SOL username",
-							SUNAT_PASSWORD: "SOL password",
-						},
-						portals: {
-							sol: { url: "e-menu.sunat.gob.pe/cl-ti-itmenu/", captcha: "NONE", use: "RHE emission" },
-							nuevaPlataforma: {
-								url: "e-menu.sunat.gob.pe/cl-ti-itmenu2/",
-								captcha: "reCAPTCHA v2",
-								use: "F616 declaration",
+				outputJSON(
+					withVersion("login", {
+						command: "login",
+						description: "Authenticate with SUNAT Clave SOL",
+						auth: {
+							envVars: {
+								SUNAT_RUC: "RUC number (11 digits)",
+								SUNAT_USER: "SOL username",
+								SUNAT_PASSWORD: "SOL password",
+							},
+							portals: {
+								sol: { url: "e-menu.sunat.gob.pe/cl-ti-itmenu/", captcha: "NONE", use: "RHE emission" },
+								nuevaPlataforma: {
+									url: "e-menu.sunat.gob.pe/cl-ti-itmenu2/",
+									captcha: "reCAPTCHA v2",
+									use: "F616 declaration",
+								},
 							},
 						},
-					},
-					flags: { "--nueva-plataforma": "Login to Nueva Plataforma (requires reCAPTCHA)" },
-				});
+						flags: { "--nueva-plataforma": "Login to Nueva Plataforma (requires reCAPTCHA)" },
+					}),
+				);
 				return;
 			}
 
 			if (resource === "cpe-catalogos") {
-				outputJSON(getCpeCatalogosSchema());
+				outputJSON(withVersion("cpe-catalogos", getCpeCatalogosSchema()));
 				return;
 			}
 
 			const schemaPath = join(SCHEMAS_DIR, `${resource}.json`);
 			try {
 				const schema = JSON.parse(readFileSync(schemaPath, "utf-8"));
-				outputJSON(schema);
+				outputJSON(withVersion(resource as SchemaName, schema));
 			} catch {
 				console.error(`Unknown schema: "${resource}". Available: ${AVAILABLE_SCHEMAS.join(", ")}`);
 				process.exit(1);


### PR DESCRIPTION
The `schema` command emitted no version, so an agent could not detect that the contract it parsed last week is the one it is parsing now.

Adds a per-resource contract version rather than the package version. Tying it to the package would move it on every unrelated patch release, so an agent diffing it would see churn on releases that changed nothing it depends on. This follows a precedent already in the repo: `src/schemas/renta.json` already carried its own `version` while the package sat at 0.8.1.

All three emit paths are covered (inline, generated, JSON files).

```
$ for r in rhe f616 renta login cpe-factura cpe-boleta cpe-nota-credito cpe-catalogos; do
    sunat-cli schema $r | jq 'has("version")'; done
before: false x8
after:  true x8
```

385 pass.