### PR TITLE
fix(display): route truncation through truncateVisible

### DIFF
--- a/packages/cli/src/commands/renta/index.ts
+++ b/packages/cli/src/commands/renta/index.ts
@@ -15,7 +15,7 @@ import {
 import { ensureRentaToken, loginRenta } from "../../renta/login.ts";
 import { hasFreshToken, readToken } from "../../renta/session.ts";
 import { output, outputError, outputSuccess } from "../../utils/output.ts";
-import { bold, dim, info, muted, ok, warn } from "../../utils/style.ts";
+import { bold, dim, info, muted, ok, truncateVisible, warn } from "../../utils/style.ts";
 
 /**
  * F709 — Renta Anual, Persona Natural.
@@ -175,7 +175,7 @@ export function createRentaCommand(): Command {
 						headers: ["CASILLA", "DESCRIPTION", "REQ", "EDIT"],
 						rows: casillas.map((c) => [
 							c.numCas,
-							(c.descripcion || "").slice(0, 58),
+							truncateVisible(c.descripcion || "", 58),
 							c.indObligatorio ? "yes" : dim("no"),
 							c.indEditable ? ok("yes") : dim("no"),
 						]),

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -1,8 +1,9 @@
 import { Command } from "commander";
-import { existsSync, readFileSync, readdirSync } from "fs";
+import { existsSync, readdirSync, readFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { output, outputError } from "../utils/output.ts";
+import { truncateVisible } from "../utils/style.ts";
 
 /**
  * Sirve la documentación del CLI desde el propio binario.
@@ -38,7 +39,7 @@ function quiereJson(): boolean {
 function resumen(md: string): string {
 	for (const line of md.split("\n")) {
 		const t = line.trim();
-		if (t && !t.startsWith("#")) return t.replace(/`/g, "").slice(0, 78);
+		if (t && !t.startsWith("#")) return truncateVisible(t.replace(/`/g, ""), 78);
 	}
 	return "";
 }
@@ -61,7 +62,10 @@ export function createSkillsCommand(): Command {
 		.description("What documentation this version ships")
 		.action(() => {
 			const items = listar();
-			if (quiereJson()) { output("json", { json: { skills: items } }); return; }
+			if (quiereJson()) {
+				output("json", { json: { skills: items } });
+				return;
+			}
 			for (const s of items) console.log(`  ${s.name.padEnd(12)} ${s.summary}`);
 		});
 
@@ -71,12 +75,17 @@ export function createSkillsCommand(): Command {
 		.action((name: string) => {
 			const file = join(SKILLS_DIR, `${name.replace(/[^a-z0-9-]/gi, "")}.md`);
 			if (!existsSync(file)) {
-				const disponibles = listar().map((s) => s.name).join(", ");
+				const disponibles = listar()
+					.map((s) => s.name)
+					.join(", ");
 				outputError(`No existe "${name}". Disponibles: ${disponibles || "(ninguno)"}`, quiereJson() ? "json" : "table");
 				return;
 			}
 			const content = readFileSync(file, "utf-8");
-			if (quiereJson()) { output("json", { json: { name, content } }); return; }
+			if (quiereJson()) {
+				output("json", { json: { name, content } });
+				return;
+			}
 			console.log(content);
 		});
 


### PR DESCRIPTION
`truncateVisible` was exported, correct, and had zero call sites, while several places truncated by hand with a bare `.slice(0, N)` and no marker. A reader could not tell a short complete value from a silently chopped one.

```
before  core   SUNAT tax automation via npx @crafter/sunat-cli (or sunat if globally installe
after   core   SUNAT tax automation via npx @crafter/sunat-cli (or sunat if globally install…
```

Alignment is unchanged: the ellipsis fits inside the existing width budget, and the DESCRIPTION column stays 58 visible chars across all 88 rows.

Machine output is untouched. `renta casillas` in JSON mode still carries the full `descripcion`.

The other 12 `.slice(0, N)` in the source are extraction, not rendering, and were left alone.

385 pass.