### PR TITLE
fix(cli): name the program as it installs, and use Peruvian Spanish

### DIFF
--- a/packages/cli/bin/sunat.ts
+++ b/packages/cli/bin/sunat.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env bun
 import { Command } from "commander";
+import pkg from "../package.json" with { type: "json" };
 import { createApiCommand } from "../src/commands/api/index.ts";
 import { createAuditCommand } from "../src/commands/audit.ts";
 import { createCpeCommand } from "../src/commands/cpe/index.ts";
 import { createF616Command } from "../src/commands/f616/index.ts";
-import { createSkillsCommand } from "../src/commands/skills.ts";
 import { createKeychainCommand } from "../src/commands/keychain.ts";
 import { createLoginCommand } from "../src/commands/login.ts";
 import { createPadronCommand } from "../src/commands/padron/index.ts";
@@ -12,14 +12,14 @@ import { createRentaCommand } from "../src/commands/renta/index.ts";
 import { createRheCommand } from "../src/commands/rhe/index.ts";
 import { createSchemaCommand } from "../src/commands/schema.ts";
 import { createSireCommand } from "../src/commands/sire/index.ts";
+import { createSkillsCommand } from "../src/commands/skills.ts";
 import { createTipoCambioCommand } from "../src/commands/tipo-cambio.ts";
 import { createWhoamiCommand } from "../src/commands/whoami.ts";
-import pkg from "../package.json" with { type: "json" };
 
 const program = new Command();
 
 program
-	.name("sunat")
+	.name("sunat-cli")
 	.description("Agent-first CLI for SUNAT tax automation")
 	.version(pkg.version)
 	.option("-o, --output <format>", "output format", "auto")

--- a/packages/cli/src/commands/f616/declarar.ts
+++ b/packages/cli/src/commands/f616/declarar.ts
@@ -61,7 +61,7 @@ export function createDeclararCommand(): Command {
 
 	cmd
 		.command("periodo <YYYY-MM>")
-		.description("Abre un periodo. Recargá el formulario antes de cambiar de periodo.")
+		.description("Abre un periodo. Recarga el formulario antes de cambiar de periodo.")
 		.requiredOption("--telefono <n>", "Teléfono para Información General")
 		.requiredOption("--profesion <p>", "Profesión del catálogo")
 		.action(async (periodo, opts, c) => {
@@ -74,7 +74,7 @@ export function createDeclararCommand(): Command {
 					json: {
 						periodo: await periodoAbierto(s),
 						habilitado: ok,
-						...(ok ? {} : { aviso: "El formulario no se habilitó. Revisá si SUNAT mostró algún aviso." }),
+						...(ok ? {} : { aviso: "El formulario no se habilitó. Revisa si SUNAT mostró algún aviso." }),
 					},
 				});
 			} catch (e) {
@@ -151,7 +151,7 @@ export function createDeclararCommand(): Command {
 					return;
 				}
 				output(format, {
-					json: { success: true, importe: r.importe, nota: "Presentá y pagá vos desde Presente/Pague." },
+					json: { success: true, importe: r.importe, nota: "Presenta y paga tú desde Presente/Pague." },
 				});
 			} catch (e) {
 				outputError(e instanceof Error ? e.message : String(e), format);


### PR DESCRIPTION
Two small fixes.

`bin/sunat.ts` declared `.name("sunat")` while the package publishes the bin as `sunat-cli`, so every `--help` screen printed `Usage: sunat ...`, naming a command the reader does not have. For most people `--help` is the whole product until they run something, and its Usage line is the one string they copy verbatim.

The `f616 declarar` help also carried Rioplatense imperatives. This CLI is for Peruvian users: tuteo, never voseo. Three lines fixed, one of which also carried the pronoun `vos`.

| Before | After |
|---|---|
| `Recargá el formulario` | `Recarga el formulario` |
| `Revisá si SUNAT` | `Revisa si SUNAT` |
| `Presentá y pagá vos desde` | `Presenta y paga tú desde` |

A sweep for the rest of the voseo family found no other hits.

385 pass.