### PR TITLE
fix(docs): name the installed command in every hint and schema

### DIFF
--- a/packages/cli/skills/sunat-cli/SKILL.md
+++ b/packages/cli/skills/sunat-cli/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: sunat-cli
-description: SUNAT tax automation CLI for Peru. Three namespaces. (A) Personas naturales (RUC 10): emit Recibos por Honorarios (RHE), file F616 monthly declarations. (B) Empresas (RUC 20): emit Comprobantes de Pago Electronicos (CPE) — Factura, Boleta, NC, ND, Guia — under `sunat cpe ...`. Use when: (1) user mentions SUNAT, RHE, recibo por honorarios, F616, impuestos Peru, (2) user wants to emit an invoice (factura/boleta) or recibo, (3) user asks about CPE, UBL 2.1, XAdES, OSE, PSE, Facturador SUNAT, (4) user says "emitir recibo", "emitir factura", "declarar F616", "anular comprobante". (C) Renta Anual (F709) read-only: consult the annual income-tax return, its casillas, filings and constancias under `sunat renta ...` — use when the user mentions renta anual, declaracion jurada anual, F709, or DJ anual. Package: @crafter/sunat-cli (npm).
+description: SUNAT tax automation CLI for Peru. Three namespaces. (A) Personas naturales (RUC 10): emit Recibos por Honorarios (RHE), file F616 monthly declarations. (B) Empresas (RUC 20): emit Comprobantes de Pago Electronicos (CPE) — Factura, Boleta, NC, ND, Guia — under `sunat-cli cpe ...`. Use when: (1) user mentions SUNAT, RHE, recibo por honorarios, F616, impuestos Peru, (2) user wants to emit an invoice (factura/boleta) or recibo, (3) user asks about CPE, UBL 2.1, XAdES, OSE, PSE, Facturador SUNAT, (4) user says "emitir recibo", "emitir factura", "declarar F616", "anular comprobante". (C) Renta Anual (F709) read-only: consult the annual income-tax return, its casillas, filings and constancias under `sunat-cli renta ...` — use when the user mentions renta anual, declaracion jurada anual, F709, or DJ anual. Package: @crafter/sunat-cli (npm).
 ---
 
 # sunat-cli
 
-SUNAT tax automation via `npx @crafter/sunat-cli` (or `sunat` if globally installed).
+SUNAT tax automation via `npx @crafter/sunat-cli` (or `sunat-cli` if globally installed).
 
 Install: `npx skills add Railly/sunat-cli -g`
 
@@ -15,7 +15,7 @@ Three ways to provide credentials (priority order):
 
 1. **Non-secret flags**: `sunat-cli login --ruc 10XXXXXXXXX --user XXXXXXXX`
 2. **Env vars**: `SUNAT_RUC`, `SUNAT_USER`, `SUNAT_PASSWORD`
-3. **OS keychain**: `sunat keychain set SUNAT_PASSWORD`
+3. **OS keychain**: `sunat-cli keychain set SUNAT_PASSWORD`
 4. **Interactive prompts**: just run `sunat-cli login` and it asks step by step
 
 ```bash
@@ -30,11 +30,11 @@ RUC and usuario are saved to `~/.sunat/config.json` after first login. Password 
 Secrets resolve as env var → OS keychain → clear error. Env vars always win, which keeps CI predictable.
 
 ```bash
-sunat keychain set CPE_CERT_PASSWORD
-sunat keychain set CPE_SOL_PASSWORD
-sunat keychain set SUNAT_API_CLIENT_SECRET
-sunat keychain list
-sunat keychain clear CPE_CERT_PASSWORD
+sunat-cli keychain set CPE_CERT_PASSWORD
+sunat-cli keychain set CPE_SOL_PASSWORD
+sunat-cli keychain set SUNAT_API_CLIENT_SECRET
+sunat-cli keychain list
+sunat-cli keychain clear CPE_CERT_PASSWORD
 ```
 
 macOS prompts `security add-generic-password` through stdin, with `-w` as the final argument.
@@ -44,7 +44,7 @@ Linux stores secrets through `secret-tool` / libsecret.
 
 ```bash
 # Emit single RHE
-sunat rhe emit --json '{
+sunat-cli rhe emit --json '{
   "empresa": "Cliente Ejemplo",
   "tipoDoc": "SIN DOCUMENTO",
   "descripcion": "Servicios de desarrollo de software",
@@ -54,16 +54,16 @@ sunat rhe emit --json '{
 }'
 
 # Preview without submitting
-sunat rhe emit --json '...' --dry-run
+sunat-cli rhe emit --json '...' --dry-run
 
 # Batch from CSV
-sunat rhe emit --batch recibos.csv
+sunat-cli rhe emit --batch recibos.csv
 
 # List issued RHEs
-sunat rhe list
+sunat-cli rhe list
 
 # Verify registration
-sunat rhe verify --month 2026-03
+sunat-cli rhe verify --month 2026-03
 ```
 
 **RHE fields**: See `references/schemas.md` for full field specs.
@@ -78,18 +78,18 @@ Key rules:
 
 ```bash
 # Single month
-sunat f616 declare --json '{
+sunat-cli f616 declare --json '{
   "periodo": "2026-03"
 }'
 
 # Preview
-sunat f616 declare --json '...' --dry-run
+sunat-cli f616 declare --json '...' --dry-run
 
 # Batch multiple months
-sunat f616 declare --batch --months "2025-03..2026-02"
+sunat-cli f616 declare --batch --months "2025-03..2026-02"
 
 # Check status
-sunat f616 status
+sunat-cli f616 status
 ```
 
 SUNAT prefills income and withholdings from registered RHE. The CLI only sets the period, so verify the prefilled amounts before submitting.
@@ -106,17 +106,17 @@ For empresas with RUC 20 emitting Factura, Boleta, NC, ND, Guia. NOT for RUC 10
 
 ```bash
 # Driver introspection
-sunat cpe doctor              # Health check active driver (default: mock)
-sunat cpe info                # Driver info (name, mode, version)
-sunat cpe --driver mock doctor
+sunat-cli cpe doctor              # Health check active driver (default: mock)
+sunat-cli cpe info                # Driver info (name, mode, version)
+sunat-cli cpe --driver mock doctor
 
 # Schemas
-sunat schema cpe-factura
-sunat schema cpe-boleta
-sunat schema cpe-nota-credito
+sunat-cli schema cpe-factura
+sunat-cli schema cpe-boleta
+sunat-cli schema cpe-nota-credito
 
 # Preview a Factura (T0, no submit)
-sunat cpe factura preview --params '{
+sunat-cli cpe factura preview --params '{
   "receptor": {"tipoDoc":"6","numDoc":"20123456789","rznSocial":"ACME SAC"},
   "items": [{"codigo":"P001","descripcion":"Consultoria","cantidad":1,"unidad":"NIU","valorUnitario":1000,"igvPct":18}],
   "totales": {"valorVenta":1000,"igv":180,"total":1180},
@@ -125,9 +125,9 @@ sunat cpe factura preview --params '{
 }'
 
 # Emit (T2, requires --yes)
-sunat cpe factura emit --params '...' --yes
-sunat cpe boleta emit --params '...' --yes
-sunat cpe nc emit --params '...' --yes
+sunat-cli cpe factura emit --params '...' --yes
+sunat-cli cpe boleta emit --params '...' --yes
+sunat-cli cpe nc emit --params '...' --yes
 ```
 
 **Drivers** (`--driver <name>` or `$CPE_DRIVER`):
@@ -144,20 +144,20 @@ Threshold S/700 dictates path:
 
 ```bash
 # Individual boleta (>= S/700) — same flow as factura
-sunat cpe boleta emit --params '{...}' --yes
+sunat-cli cpe boleta emit --params '{...}' --yes
 
 # Boleta < S/700 — queue first
-sunat cpe boleta queue --params '{...}'
-sunat cpe boleta queue:list                   # list all pending dates
-sunat cpe boleta queue:list --fecha 2026-04-29 # entries for one date
+sunat-cli cpe boleta queue --params '{...}'
+sunat-cli cpe boleta queue:list                   # list all pending dates
+sunat-cli cpe boleta queue:list --fecha 2026-04-29 # entries for one date
 
 # At end of day (or next day, plazo 7 days), send the resumen
-sunat cpe --driver sunat-direct resumen send --fecha 2026-04-29 --correlativo 1 --yes --wait
+sunat-cli cpe --driver sunat-direct resumen send --fecha 2026-04-29 --correlativo 1 --yes --wait
 # Returns ticket; --wait polls getStatus until CDR (max 5min)
 
 # Or fire-and-forget
-sunat cpe --driver sunat-direct resumen send --fecha 2026-04-29 --correlativo 1 --yes
-sunat cpe --driver sunat-direct resumen status --ticket 1234567890123 --wait
+sunat-cli cpe --driver sunat-direct resumen send --fecha 2026-04-29 --correlativo 1 --yes
+sunat-cli cpe --driver sunat-direct resumen status --ticket 1234567890123 --wait
 ```
 
 ### Comunicación de Baja (anular CPE post-emisión)
@@ -165,7 +165,7 @@ sunat cpe --driver sunat-direct resumen status --ticket 1234567890123 --wait
 Plazo 7 días desde fechaEmision del documento a anular.
 
 ```bash
-sunat cpe --driver sunat-direct baja send --params '{
+sunat-cli cpe --driver sunat-direct baja send --params '{
   "fechaEmisionDocs": "2026-04-29",
   "entries": [
     { "tipoDoc": "03", "serie": "B001", "numero": 100, "motivo": "Anulacion por error en datos" }
@@ -181,7 +181,7 @@ Returns `cdrCode=0` (Aceptado) end-to-end.
 
 ```bash
 # 1. Save a profile (replace with YOUR RUC + razon social)
-sunat cpe profile set --name beta --ruc 20131312955 --razon-social "ACME SAC" \
+sunat-cli cpe profile set --name beta --ruc 20131312955 --razon-social "ACME SAC" \
   --mode beta --cert-path /abs/path/to/cert.pfx --sol-usuario MODATOS1 --default
 
 # 2. Set sensitive vars or keychain secrets (NEVER commit)
@@ -190,17 +190,17 @@ export CPE_CERT_PASSWORD='your-pfx-password'
 export CPE_SOL_PASSWORD='your-clave-sol'
 
 # Keychain alternative for local machines
-sunat keychain set CPE_CERT_PASSWORD
-sunat keychain set CPE_SOL_PASSWORD
+sunat-cli keychain set CPE_CERT_PASSWORD
+sunat-cli keychain set CPE_SOL_PASSWORD
 
 # 3. Verify
-sunat cpe --driver sunat-direct doctor
+sunat-cli cpe --driver sunat-direct doctor
 # Checks: config_resolved, cert_file_exists, cert_loaded (validUntil),
 #         cert_expiry_warning (if <30 days), sunat_reachable (WSDL ping),
 #         stale_pendings (alerts if there are pending audit entries >1h old)
 
 # 4. Emit a real Factura against SUNAT beta
-sunat cpe --driver sunat-direct factura emit --params '{...}' --yes
+sunat-cli cpe --driver sunat-direct factura emit --params '{...}' --yes
 # Returns CDR responseCode=0 (Aceptado) on success.
 
 # 5. Re-running with the same serie+numero returns cached CDR (idempotent)
@@ -251,7 +251,7 @@ export CPE_SOL_PASSWORD='clave-sol'
 
 ```bash
 # Submit (sign + zip + base64 + POST + optional polling)
-sunat cpe gre emit --params '{
+sunat-cli cpe gre emit --params '{
   "tipoDoc": "09",
   "serie": "T001",
   "numero": 1,
@@ -271,7 +271,7 @@ sunat cpe gre emit --params '{
 }' --yes --wait
 
 # Independent status check
-sunat cpe gre status --ticket 20240100000001 --wait
+sunat-cli cpe gre status --ticket 20240100000001 --wait
 ```
 
 Async response codes:
@@ -294,7 +294,7 @@ export SUNAT_API_CLIENT_SECRET=...
 ```
 
 ```bash
-sunat cpe consulta \
+sunat-cli cpe consulta \
   --ruc-emisor 20131312955 --tipo 01 --serie F001 --numero 1234 \
   --fecha 2026-04-29 --monto 118
 # Returns: estadoCp (Aceptado/Anulado), estadoRuc (Activo/Baja), condDomiRuc (Habido/No Habido)
@@ -321,45 +321,45 @@ export SUNAT_PASSWORD='clave-sol'
 Monthly RVIE (Ventas) workflow:
 ```bash
 # 1. See available periodos
-sunat sire ventas periodos
+sunat-cli sire ventas periodos
 
 # 2. Download SUNAT's pre-built proposal for the period (async — returns ticket)
-sunat sire ventas propuesta --periodo 202404 --wait --out propuesta-202404.zip
+sunat-cli sire ventas propuesta --periodo 202404 --wait --out propuesta-202404.zip
 
 # 3. Review the .zip contents (TXT con todos tus comprobantes)
 
 # 4a. Accept as-is
-sunat sire ventas aceptar --periodo 202404 --yes
+sunat-cli sire ventas aceptar --periodo 202404 --yes
 
 # 4b. Or replace SUNAT's proposal with your own .zip (T2, TUS.IO upload)
-sunat sire ventas reemplazar --periodo 202404 --file mi-propuesta.zip --yes --wait
+sunat-cli sire ventas reemplazar --periodo 202404 --file mi-propuesta.zip --yes --wait
 
 # 4c. Or import additional comprobantes not in the proposal
-sunat sire ventas importar --periodo 202404 --file extra.zip --tipo propuesta --yes --wait
+sunat-cli sire ventas importar --periodo 202404 --file extra.zip --tipo propuesta --yes --wait
 # --tipo: propuesta | preliminar | ajustes | ajustes-anteriores
 
 # 5. Download the final RVIE PDF/TXT once accepted
-sunat sire ventas descargar --periodo 202404 --wait --out rvie-202404.zip
+sunat-cli sire ventas descargar --periodo 202404 --wait --out rvie-202404.zip
 ```
 
 Same flow for RCE (Compras):
 ```bash
-sunat sire compras periodos
-sunat sire compras propuesta --periodo 202404 --wait --out compras-202404.zip
-sunat sire compras ticket --num 20240100000123 --wait
+sunat-cli sire compras periodos
+sunat-cli sire compras propuesta --periodo 202404 --wait --out compras-202404.zip
+sunat-cli sire compras ticket --num 20240100000123 --wait
 ```
 
 Polling: `--wait` polls getStatus with backoff (2s/4s/8s/16s/30s, max 5min).
 Without `--wait`, returns the ticket and you poll independently with
-`sunat sire {ventas|compras} ticket --num <id> [--wait]`.
+`sunat-cli sire {ventas|compras} ticket --num <id> [--wait]`.
 
 ### Tipo de Cambio oficial SUNAT
 
 ```bash
-sunat tipo-cambio                       # today's USD/PEN
-sunat tipo-cambio --fecha 2026-04-15    # historical (immutable)
-sunat tipo-cambio --force               # bypass cache
-sunat tipo-cambio cached --fecha 2026-04-15  # cache-only, no scrape
+sunat-cli tipo-cambio                       # today's USD/PEN
+sunat-cli tipo-cambio --fecha 2026-04-15    # historical (immutable)
+sunat-cli tipo-cambio --force               # bypass cache
+sunat-cli tipo-cambio cached --fecha 2026-04-15  # cache-only, no scrape
 ```
 
 Scrapes the official SUNAT portal via agent-browser (WAF blocks direct
@@ -369,10 +369,10 @@ since SUNAT TCs are immutable.
 ### Padrón RUC online (single lookup, no padrón sync)
 
 ```bash
-sunat padron ruc-online 20131312955   # ~5-10s, drives SUNAT portal via browser
+sunat-cli padron ruc-online 20131312955   # ~5-10s, drives SUNAT portal via browser
 ```
 
-For batch: always use `sunat padron ruc/batch` (offline padrón, instantaneous).
+For batch: always use `sunat-cli padron ruc/batch` (offline padrón, instantaneous).
 
 ### Padrón Reducido del RUC (offline)
 
@@ -380,13 +380,13 @@ Local copy of the SUNAT RUC registry. ~370MB ZIP, ~600MB TXT, ~3.5M entries.
 Refreshes automatically every 24h. No auth, no captcha, no third-party API.
 
 ```bash
-sunat padron status                 # see if synced + how stale
-sunat padron sync                   # downloads if missing or >24h old; --force to override
-sunat padron ruc 20131312955        # lookup razon social, estado, condicion, dirección
+sunat-cli padron status                 # see if synced + how stale
+sunat-cli padron sync                   # downloads if missing or >24h old; --force to override
+sunat-cli padron ruc 20131312955        # lookup razon social, estado, condicion, dirección
 echo "20131312955
 20100070970
-20536557858" | sunat padron batch   # batch lookup via stdin
-sunat padron batch --file rucs.csv  # or from CSV (RUC in first column)
+20536557858" | sunat-cli padron batch   # batch lookup via stdin
+sunat-cli padron batch --file rucs.csv  # or from CSV (RUC in first column)
 ```
 
 First lookup after sync takes 5-15s (streaming scan of 600MB). Batch is one
@@ -395,15 +395,15 @@ scan regardless of N RUCs.
 ### API & Schema
 
 ```bash
-sunat api token              # Validate OAuth2 credentials without printing the token
-sunat schema rhe             # JSON schema for RHE fields
-sunat schema f616            # JSON schema for F616 fields
-sunat schema cpe-factura     # JSON schema for Factura Electronica
-sunat schema cpe-boleta      # JSON schema for Boleta de Venta
-sunat schema cpe-nota-credito
+sunat-cli api token              # Validate OAuth2 credentials without printing the token
+sunat-cli schema rhe             # JSON schema for RHE fields
+sunat-cli schema f616            # JSON schema for F616 fields
+sunat-cli schema cpe-factura     # JSON schema for Factura Electronica
+sunat-cli schema cpe-boleta      # JSON schema for Boleta de Venta
+sunat-cli schema cpe-nota-credito
 ```
 
-Use `sunat schema <resource>` to get machine-readable field definitions before constructing payloads.
+Use `sunat-cli schema <resource>` to get machine-readable field definitions before constructing payloads.
 
 ## Renta Anual — F709 (Persona Natural)
 
@@ -492,18 +492,18 @@ All commands support `--output <format>`:
 ## Common Workflows
 
 **Monthly routine (4ta categoria)**:
-1. `sunat login --nueva-plataforma`
-2. `sunat f616 declare --json '{"periodo":"2026-03"}' --dry-run`
+1. `sunat-cli login --nueva-plataforma`
+2. `sunat-cli f616 declare --json '{"periodo":"2026-03"}' --dry-run`
 3. Review dry-run output
 4. Remove `--dry-run` to submit
 
 **Emit an RHE**:
-1. `sunat login`
-2. `sunat rhe emit --json '{"empresa":"Cliente Ejemplo","tipoDoc":"SIN DOCUMENTO","descripcion":"Servicios de desarrollo de software - Marzo 2026","monto":6700,"moneda":"USD","medioPago":"TRANSFERENCIA"}'`
-3. `sunat rhe verify --month 2026-03`
+1. `sunat-cli login`
+2. `sunat-cli rhe emit --json '{"empresa":"Cliente Ejemplo","tipoDoc":"SIN DOCUMENTO","descripcion":"Servicios de desarrollo de software - Marzo 2026","monto":6700,"moneda":"USD","medioPago":"TRANSFERENCIA"}'`
+3. `sunat-cli rhe verify --month 2026-03`
 
 ## Error Handling
 
-- Session expired: re-run `sunat login`
+- Session expired: re-run `sunat-cli login`
 - reCAPTCHA required: only for Nueva Plataforma, one-time per session
 - Network timeout: retry, SUNAT portals are slow

--- a/packages/cli/src/commands/cpe/RESEARCH.md
+++ b/packages/cli/src/commands/cpe/RESEARCH.md
@@ -359,8 +359,8 @@ Convencion: `cpe {noun} {verb} [args] [flags]`. Binario sugerido: `cpe` (corto, 
 
 | Command | Trust | Description | JSON Output |
 |---------|-------|-------------|-------------|
-| `sunat keychain set CPE_SOL_PASSWORD` | T1 | Guarda la Clave SOL mediante un prompt oculto del keychain del sistema. | `{ success, key }` |
-| `sunat keychain set CPE_CERT_PASSWORD` | T1 | Guarda la clave PFX mediante un prompt oculto del keychain del sistema. | `{ success, key }` |
+| `sunat-cli keychain set CPE_SOL_PASSWORD` | T1 | Guarda la Clave SOL mediante un prompt oculto del keychain del sistema. | `{ success, key }` |
+| `sunat-cli keychain set CPE_CERT_PASSWORD` | T1 | Guarda la clave PFX mediante un prompt oculto del keychain del sistema. | `{ success, key }` |
 | `cpe driver set facturador\|sunat-direct\|nubefact\|apisperu` | T1 | Cambia driver. Persiste en config. | `{ driver }` |
 | `cpe webhook register --url {url} --events {emit,fail,cdr} [--secret {hmac}]` | T1 | Registra webhook local que se dispara con eventos | `{ id, url, events }` |
 
@@ -815,10 +815,10 @@ Standard CS biome config (single quotes, 2 spaces, trailing comma, ordered impor
 
 ### SUNAT auth flow
 
-1. Configura RUC + user y ejecuta `sunat keychain set CPE_SOL_PASSWORD`.
+1. Configura RUC + user y ejecuta `sunat-cli keychain set CPE_SOL_PASSWORD`.
    - Persiste solo RUC + user en config. Password NO se persiste.
    - Validacion: hace `getStatus("0000000000")` a SUNAT con esos creds. Si SUNAT responde 401, falla.
-2. Configura el PFX y ejecuta `sunat keychain set CPE_CERT_PASSWORD`.
+2. Configura el PFX y ejecuta `sunat-cli keychain set CPE_CERT_PASSWORD`.
    - Copia PFX a `~/.cpe/certs/{ruc}.pfx` con perms 0600.
    - Extrae validUntil, issuer, subject.
    - Password del cert: idem env var o keychain del OS.
@@ -1024,8 +1024,8 @@ cpe schema factura.emit --json
 
 ```bash
 cpe doctor --json                                           # Verifica deps
-sunat keychain set CPE_SOL_PASSWORD
-sunat keychain set CPE_CERT_PASSWORD
+sunat-cli keychain set CPE_SOL_PASSWORD
+sunat-cli keychain set CPE_CERT_PASSWORD
 cpe driver set sunat-direct                                 # o `facturador`, `nubefact`, `apisperu`, `mock`
 cpe doctor --json                                           # Re-verifica
 ```

--- a/packages/cli/src/commands/cpe/index.ts
+++ b/packages/cli/src/commands/cpe/index.ts
@@ -53,7 +53,7 @@ function notImplemented(verb: string, format: Format): never {
 
 export function createCpeCommand(): Command {
 	const cpe = new Command("cpe").description(
-		"Comprobantes de Pago Electronicos (CPE) for empresas con RUC 20. Factura, Boleta, NC, ND, Guia. NOT for personas naturales — use 'sunat rhe'.",
+		"Comprobantes de Pago Electronicos (CPE) for empresas con RUC 20. Factura, Boleta, NC, ND, Guia. NOT for personas naturales — use 'sunat-cli rhe'.",
 	);
 
 	cpe.option(
@@ -93,7 +93,7 @@ export function createCpeCommand(): Command {
 	factura
 		.command("preview")
 		.description("Build + sign + validate locally. Does NOT submit. T0.")
-		.requiredOption("--params <json>", "JSON payload (see: sunat schema cpe-factura)")
+		.requiredOption("--params <json>", "JSON payload (see: sunat-cli schema cpe-factura)")
 		.action(async (opts, cmd) => {
 			const format = getFormat(cmd);
 			try {
@@ -193,7 +193,7 @@ export function createCpeCommand(): Command {
 	boleta
 		.command("preview")
 		.description("Build + sign + validate locally. Does NOT submit. T0.")
-		.requiredOption("--params <json>", "JSON payload (see: sunat schema cpe-boleta)")
+		.requiredOption("--params <json>", "JSON payload (see: sunat-cli schema cpe-boleta)")
 		.action(async (opts, cmd) => {
 			const format = getFormat(cmd);
 			try {
@@ -275,7 +275,7 @@ export function createCpeCommand(): Command {
 						fechaEmision: input.fechaEmision,
 						file: queued.file,
 						totalQueuedToday: queued.total,
-						hint: `When done emitting boletas for the day, run: sunat cpe resumen send --fecha ${input.fechaEmision}`,
+						hint: `When done emitting boletas for the day, run: sunat-cli cpe resumen send --fecha ${input.fechaEmision}`,
 					},
 				});
 			} catch (err) {
@@ -393,14 +393,14 @@ export function createCpeCommand(): Command {
 		.allowUnknownOption(true)
 		.helpOption(false)
 		.action(() => {
-			console.error("Use 'sunat cpe gre <verb>' instead. 'cpe guia' is an alias placeholder.");
+			console.error("Use 'sunat-cli cpe gre <verb>' instead. 'cpe guia' is an alias placeholder.");
 			process.exit(1);
 		});
 
 	gre
 		.command("emit")
 		.description("Sign + zip + base64 + POST a Guía de Remisión via SUNAT GRE REST API. Async — returns ticket. T2.")
-		.requiredOption("--params <json>", "JSON payload (run: sunat schema cpe-gre)")
+		.requiredOption("--params <json>", "JSON payload (run: sunat-cli schema cpe-gre)")
 		.option("--dry-run", "Build + sign locally, do NOT submit")
 		.option("--yes", "Skip T2 confirmation")
 		.option("--wait", "After submit, poll the ticket until completed/rejected")
@@ -415,7 +415,7 @@ export function createCpeCommand(): Command {
 				const ctx = resolveCpeContext();
 				const input = JSON.parse(opts.params);
 				if (!input.envio || !input.destinatario || !input.items?.length) {
-					outputError("GRE requires destinatario, envio, items. Run: sunat schema cpe-gre", format);
+					outputError("GRE requires destinatario, envio, items. Run: sunat-cli schema cpe-gre", format);
 					return;
 				}
 				input.tipoDoc = input.tipoDoc || "09";
@@ -475,7 +475,7 @@ export function createCpeCommand(): Command {
 							submitted: true,
 							filename,
 							numTicket: sendResp.numTicket,
-							hint: `Poll status with: sunat cpe gre status --ticket ${sendResp.numTicket}`,
+							hint: `Poll status with: sunat-cli cpe gre status --ticket ${sendResp.numTicket}`,
 						},
 					});
 					audit({
@@ -614,7 +614,7 @@ export function createCpeCommand(): Command {
 							ticket: submitResult.ticket,
 							id: submitResult.id,
 							submitted: queued.length,
-							hint: `Poll status with: sunat cpe resumen status --ticket ${submitResult.ticket}`,
+							hint: `Poll status with: sunat-cli cpe resumen status --ticket ${submitResult.ticket}`,
 						},
 					});
 					return;
@@ -765,7 +765,7 @@ export function createCpeCommand(): Command {
 							ticket: submitResult.ticket,
 							id: submitResult.id,
 							submitted: raw.entries.length,
-							hint: `Poll status with: sunat cpe resumen status --ticket ${submitResult.ticket}`,
+							hint: `Poll status with: sunat-cli cpe resumen status --ticket ${submitResult.ticket}`,
 						},
 					});
 					return;
@@ -941,7 +941,7 @@ export function createCpeCommand(): Command {
 			try {
 				const config = loadCpeConfig();
 				if (!config.profiles[name]) {
-					outputError(`CPE profile "${name}" not found. Run: sunat cpe profile list`, format);
+					outputError(`CPE profile "${name}" not found. Run: sunat-cli cpe profile list`, format);
 					return;
 				}
 				config.defaultProfile = name;

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -28,11 +28,11 @@ async function getOrPromptCredentials(
 
 	if (!isTTY) {
 		throw new Error(
-			"Missing credentials. Pass --ruc and --user, set SUNAT_RUC, SUNAT_USER and SUNAT_PASSWORD, or store SUNAT_PASSWORD with sunat keychain set",
+			"Missing credentials. Pass --ruc and --user, set SUNAT_RUC, SUNAT_USER and SUNAT_PASSWORD, or store SUNAT_PASSWORD with sunat-cli keychain set",
 		);
 	}
 
-	p.intro("sunat login -- first time setup");
+	p.intro("sunat-cli login -- first time setup");
 
 	if (!ruc) {
 		const value = await p.text({

--- a/packages/cli/src/commands/padron/index.ts
+++ b/packages/cli/src/commands/padron/index.ts
@@ -32,7 +32,7 @@ export function createPadronCommand(): Command {
 			const format = getFormat(cmd);
 			const meta = loadMeta();
 			if (!meta) {
-				output(format, { json: { synced: false, hint: "Run: sunat padron sync" } });
+				output(format, { json: { synced: false, hint: "Run: sunat-cli padron sync" } });
 				return;
 			}
 			output(format, {

--- a/packages/cli/src/commands/rhe/index.ts
+++ b/packages/cli/src/commands/rhe/index.ts
@@ -71,7 +71,7 @@ export function createRheCommand(): Command {
 						output(format, { json: { success: true, ...result } });
 					}
 				} else {
-					outputError("Provide --json or --batch. Use 'sunat schema rhe' to see fields.", format);
+					outputError("Provide --json or --batch. Use 'sunat-cli schema rhe' to see fields.", format);
 				}
 			} catch (err) {
 				const msg = err instanceof Error ? err.message : String(err);

--- a/packages/cli/src/commands/sire/index.ts
+++ b/packages/cli/src/commands/sire/index.ts
@@ -81,7 +81,7 @@ function bookCommand(libroAlias: "ventas" | "compras", codLibro: CodLibro): Comm
 					output(format, {
 						json: {
 							numTicket,
-							hint: `Poll status with: sunat sire ${libroAlias} ticket --num ${numTicket}`,
+							hint: `Poll status with: sunat-cli sire ${libroAlias} ticket --num ${numTicket}`,
 						},
 					});
 					return;
@@ -132,7 +132,7 @@ function bookCommand(libroAlias: "ventas" | "compras", codLibro: CodLibro): Comm
 						statusDesc: result.statusDesc,
 						archivoReporte: archivos,
 						hint: archivos[0]
-							? `Download with: sunat sire ${libroAlias} archivo --nombre ${archivos[0].nomArchivoReporte} --periodo ${opts.periodo} --out path`
+							? `Download with: sunat-cli sire ${libroAlias} archivo --nombre ${archivos[0].nomArchivoReporte} --periodo ${opts.periodo} --out path`
 							: undefined,
 					},
 				});
@@ -308,7 +308,7 @@ function bookCommand(libroAlias: "ventas" | "compras", codLibro: CodLibro): Comm
 						numTicket: result.numTicket || null,
 						uploadUrl: result.uploadUrl,
 						hint: result.numTicket
-							? `Poll status with: sunat sire ${libroAlias} ticket --num ${result.numTicket}`
+							? `Poll status with: sunat-cli sire ${libroAlias} ticket --num ${result.numTicket}`
 							: "No ticket extracted from upload location. Inspect uploadUrl + run consultaestadotickets manually.",
 					},
 				});
@@ -359,7 +359,7 @@ function bookCommand(libroAlias: "ventas" | "compras", codLibro: CodLibro): Comm
 						details: result as unknown as Record<string, unknown>,
 					});
 					output(format, {
-						json: { ...result, hint: `Poll status with: sunat sire ventas ticket --num ${result.numTicket}` },
+						json: { ...result, hint: `Poll status with: sunat-cli sire ventas ticket --num ${result.numTicket}` },
 					});
 				} catch (err) {
 					outputError(err instanceof Error ? err.message : String(err), format);
@@ -379,7 +379,7 @@ function bookCommand(libroAlias: "ventas" | "compras", codLibro: CodLibro): Comm
 					const creds = resolveSireCreds();
 					const numTicket = await descargarRvie(opts.periodo, creds);
 					if (!opts.wait) {
-						output(format, { json: { numTicket, hint: `Poll: sunat sire ventas ticket --num ${numTicket}` } });
+						output(format, { json: { numTicket, hint: `Poll: sunat-cli sire ventas ticket --num ${numTicket}` } });
 						return;
 					}
 					const result = await pollTicket({ creds, numTicket, timeoutMs: Number.parseInt(opts.timeout, 10) });

--- a/packages/cli/src/cpe/config.ts
+++ b/packages/cli/src/cpe/config.ts
@@ -84,7 +84,7 @@ export function resolveCpeContext(profileName?: string): ResolvedCpeContext {
 	const emisorRuc = process.env.CPE_EMISOR_RUC || profile?.emisor.ruc;
 	const emisorRznSocial = process.env.CPE_EMISOR_RAZON_SOCIAL || profile?.emisor.razonSocial;
 	if (!emisorRuc)
-		throw new Error("Emisor RUC not configured. Set CPE_EMISOR_RUC env var or run 'sunat cpe profile set'.");
+		throw new Error("Emisor RUC not configured. Set CPE_EMISOR_RUC env var or run 'sunat-cli cpe profile set'.");
 	if (!emisorRznSocial) throw new Error("Emisor razonSocial not configured. Set CPE_EMISOR_RAZON_SOCIAL env var.");
 
 	const mode = (process.env.CPE_MODE || profile?.mode || "beta") as "beta" | "prod";

--- a/packages/cli/src/cpe/drivers/sunat-direct.ts
+++ b/packages/cli/src/cpe/drivers/sunat-direct.ts
@@ -222,7 +222,7 @@ export class SunatDirectDriver implements CpeDriver {
 		// Above the threshold, they go individually via sendBill — same path as factura.
 		if (!boletaRequiresIndividualSubmission(input.totales.total)) {
 			throw new Error(
-				`Boleta total S/${input.totales.total.toFixed(2)} < S/700: must be sent via daily summary. Use 'sunat cpe boleta queue' + 'sunat cpe resumen send' (coming in next phase). Or set --force-individual to override (not recommended; SUNAT may reject).`,
+				`Boleta total S/${input.totales.total.toFixed(2)} < S/700: must be sent via daily summary. Use 'sunat-cli cpe boleta queue' + 'sunat-cli cpe resumen send' (coming in next phase). Or set --force-individual to override (not recommended; SUNAT may reject).`,
 			);
 		}
 

--- a/packages/cli/src/cpe/parsers.ts
+++ b/packages/cli/src/cpe/parsers.ts
@@ -7,7 +7,7 @@ function todayIso(): string {
 export function parseFacturaInput(payload: string): FacturaInput {
 	const raw = JSON.parse(payload) as Record<string, unknown>;
 	if (!raw.receptor || !raw.items || !raw.totales) {
-		throw new Error("Missing required fields. Run: sunat schema cpe-factura");
+		throw new Error("Missing required fields. Run: sunat-cli schema cpe-factura");
 	}
 	return {
 		receptor: raw.receptor as FacturaInput["receptor"],
@@ -25,7 +25,7 @@ export function parseNotaInput(payload: string): NotaCreditoInput {
 	const base = parseFacturaInput(payload);
 	const raw = JSON.parse(payload) as Record<string, unknown>;
 	if (!raw.refSerie || !raw.refNumero || !raw.tipoNota) {
-		throw new Error("Nota requires refSerie, refNumero, tipoNota. Run: sunat schema cpe-nota-credito");
+		throw new Error("Nota requires refSerie, refNumero, tipoNota. Run: sunat-cli schema cpe-nota-credito");
 	}
 	return {
 		...base,

--- a/packages/cli/src/data/config.ts
+++ b/packages/cli/src/data/config.ts
@@ -50,9 +50,9 @@ export function getCredentials(): { ruc: string; usuario: string; password: stri
 	const usuario = process.env.SUNAT_USER || config.usuario;
 	const password = resolveSecret(["SUNAT_PASSWORD"]);
 
-	if (!ruc) throw new Error("RUC not configured. Set SUNAT_RUC env var or run: sunat config set ruc <value>");
+	if (!ruc) throw new Error("RUC not configured. Set SUNAT_RUC env var or run: sunat-cli config set ruc <value>");
 	if (!usuario)
-		throw new Error("Usuario not configured. Set SUNAT_USER env var or run: sunat config set usuario <value>");
+		throw new Error("Usuario not configured. Set SUNAT_USER env var or run: sunat-cli config set usuario <value>");
 	if (!password) throw new Error(missingSecretMessage(["SUNAT_PASSWORD"], "Password"));
 
 	return { ruc, usuario, password };

--- a/packages/cli/src/data/keychain.ts
+++ b/packages/cli/src/data/keychain.ts
@@ -122,5 +122,5 @@ export function resolveSecret(envNames: readonly string[]): string | undefined {
 }
 
 export function missingSecretMessage(envNames: readonly string[], label = "Secret"): string {
-	return `${label} missing. Set ${envNames.join(" or ")} env var, or store it with: sunat keychain set ${envNames[0]}`;
+	return `${label} missing. Set ${envNames.join(" or ")} env var, or store it with: sunat-cli keychain set ${envNames[0]}`;
 }

--- a/packages/cli/src/schemas/cpe-factura.json
+++ b/packages/cli/src/schemas/cpe-factura.json
@@ -1,7 +1,7 @@
 {
 	"command": "cpe factura emit",
 	"description": "Emit a Factura Electronica (CPE tipo 01) for a RUC 20 emisor. Trust level T2.",
-	"audience": "Empresa emisora con RUC 20. NOT for personas naturales (use 'sunat rhe emit').",
+	"audience": "Empresa emisora con RUC 20. NOT for personas naturales (use 'sunat-cli rhe emit').",
 	"fields": {
 		"receptor": {
 			"type": "object",

--- a/packages/cli/src/schemas/f616.json
+++ b/packages/cli/src/schemas/f616.json
@@ -38,6 +38,6 @@
 	"computed": {
 		"pagoACuenta": "Computed by SUNAT from its own prefilled figures, not by this CLI."
 	},
-	"auth": "Requires Nueva Plataforma session. Run 'sunat login --nueva-plataforma' first.",
+	"auth": "Requires Nueva Plataforma session. Run 'sunat-cli login --nueva-plataforma' first.",
 	"portal": "Nueva Plataforma (e-menu.sunat.gob.pe/cl-ti-itmenu2/) — requires reCAPTCHA v2 (one-time)"
 }

--- a/packages/cli/src/schemas/rhe.json
+++ b/packages/cli/src/schemas/rhe.json
@@ -51,6 +51,6 @@
 		"--output json": "Machine-readable JSON output",
 		"--batch <file>": "Process multiple RHEs from CSV file"
 	},
-	"auth": "Requires SOL session. Run 'sunat login' first.",
+	"auth": "Requires SOL session. Run 'sunat-cli login' first.",
 	"portal": "SOL viejo (e-menu.sunat.gob.pe/cl-ti-itmenu/) — NO CAPTCHA"
 }

--- a/packages/cli/src/skills/core.md
+++ b/packages/cli/src/skills/core.md
@@ -1,6 +1,6 @@
 # sunat-cli
 
-SUNAT tax automation via `npx @crafter/sunat-cli` (or `sunat` if globally installed).
+SUNAT tax automation via `npx @crafter/sunat-cli` (or `sunat-cli` if globally installed).
 
 Install: `npm install -g @crafter/sunat-cli`
 
@@ -27,7 +27,7 @@ RUC and usuario are saved to `~/.sunat/config.json` after first login. Password 
 
 ```bash
 # Emit single RHE
-sunat rhe emit --json '{
+sunat-cli rhe emit --json '{
   "empresa": "Cliente Ejemplo",
   "tipoDoc": "SIN DOCUMENTO",
   "descripcion": "Servicios de desarrollo de software",
@@ -37,19 +37,19 @@ sunat rhe emit --json '{
 }'
 
 # Preview without submitting
-sunat rhe emit --json '...' --dry-run
+sunat-cli rhe emit --json '...' --dry-run
 
 # Batch from CSV
-sunat rhe emit --batch recibos.csv
+sunat-cli rhe emit --batch recibos.csv
 
 # List issued RHEs
-sunat rhe list
+sunat-cli rhe list
 
 # Verify registration
-sunat rhe verify --month 2026-03
+sunat-cli rhe verify --month 2026-03
 ```
 
-**RHE fields**: `sunat skills get schemas` for the full field specs.
+**RHE fields**: `sunat-cli skills get schemas` for the full field specs.
 
 Key rules:
 - `tipoDoc`: Use `SIN DOCUMENTO` for foreign companies (no RUC/DNI)
@@ -69,8 +69,8 @@ Two paths, and they do different things.
 **Reading (T0, headless):**
 
 ```bash
-sunat f616 periodo 2026-03      # opens a period through the API
-sunat f616 oficios              # profession catalog
+sunat-cli f616 periodo 2026-03      # opens a period through the API
+sunat-cli f616 oficios              # profession catalog
 ```
 
 `periodo` returns the comprobantes already registered, the due date (`fec_ven`),
@@ -80,11 +80,11 @@ is cached.
 **Filling the form (T2, needs a browser):**
 
 ```bash
-sunat f616 declarar estado
-sunat f616 declarar periodo 2025-11
-sunat f616 declarar ingreso --fecha 17/11/2025 --monto 21054 --cliente "CLIENTE EJEMPLO"
-sunat f616 declarar bandeja
-sunat f616 declarar constancias --dir ~/Downloads/constancias
+sunat-cli f616 declarar estado
+sunat-cli f616 declarar periodo 2025-11
+sunat-cli f616 declarar ingreso --fecha 17/11/2025 --monto 21054 --cliente "CLIENTE EJEMPLO"
+sunat-cli f616 declarar bandeja
+sunat-cli f616 declarar constancias --dir ~/Downloads/constancias
 ```
 
 This is what unlocks filing months that went by: **the F616 does not need the RHE
@@ -115,12 +115,12 @@ then ignored by the code. Prefer `declarar`.
 ### API & Schema
 
 ```bash
-sunat api token              # Validate OAuth2 credentials without printing the token
-sunat schema rhe             # JSON schema for RHE fields
-sunat schema f616            # JSON schema for F616 fields
+sunat-cli api token              # Validate OAuth2 credentials without printing the token
+sunat-cli schema rhe             # JSON schema for RHE fields
+sunat-cli schema f616            # JSON schema for F616 fields
 ```
 
-Use `sunat schema <resource>` to get machine-readable field definitions before constructing payloads.
+Use `sunat-cli schema <resource>` to get machine-readable field definitions before constructing payloads.
 
 ## Output Formats
 
@@ -131,12 +131,12 @@ All commands support `--output <format>`:
 ## Common Workflows
 
 **Monthly routine (4ta categoria)**:
-1. `sunat login --nueva-plataforma`
+1. `sunat-cli login --nueva-plataforma`
 2. Open the F616 in the browser (menu → Trabajadores Independientes - 616)
-3. `sunat f616 declarar periodo 2026-07`
-4. `sunat f616 declarar ingreso --fecha 14/07/2026 --monto <bruto en soles> --cliente "<nombre>"`
-5. `sunat f616 declarar estado` and check casilla 355 against your own figure
-6. `sunat f616 declarar bandeja`
+3. `sunat-cli f616 declarar periodo 2026-07`
+4. `sunat-cli f616 declarar ingreso --fecha 14/07/2026 --monto <bruto en soles> --cliente "<nombre>"`
+5. `sunat-cli f616 declarar estado` and check casilla 355 against your own figure
+6. `sunat-cli f616 declarar bandeja`
 7. Present and pay from the portal yourself
 
 **Filing months that went by**: same loop, one period at a time, **reloading the
@@ -144,13 +144,13 @@ form between periods**. Eight periods spanning nine months were filed this way o
 2026-08-22 without emitting a single RHE.
 
 **Emit an RHE**:
-1. `sunat login`
-2. `sunat rhe emit --json '{"empresa":"Cliente Ejemplo","tipoDoc":"SIN DOCUMENTO","descripcion":"Servicios de desarrollo de software - Marzo 2026","monto":6700,"moneda":"USD","medioPago":"TRANSFERENCIA","tipoCambio":3.75}' --dry-run`
-3. `sunat rhe verify --month 2026-03`
+1. `sunat-cli login`
+2. `sunat-cli rhe emit --json '{"empresa":"Cliente Ejemplo","tipoDoc":"SIN DOCUMENTO","descripcion":"Servicios de desarrollo de software - Marzo 2026","monto":6700,"moneda":"USD","medioPago":"TRANSFERENCIA","tipoCambio":3.75}' --dry-run`
+3. `sunat-cli rhe verify --month 2026-03`
 
 ## Error Handling
 
-- Session expired: re-run `sunat login`
+- Session expired: re-run `sunat-cli login`
 - `Error en la invocación`: enter Nueva Plataforma from SOL viejo, not direct URL login
 - reCAPTCHA required: keep browser flow supervised
 - Network timeout: retry, SUNAT portals are slow
@@ -158,7 +158,7 @@ form between periods**. Eight periods spanning nine months were filed this way o
 ## More
 
 ```bash
-sunat skills get schemas     # field specs for RHE and F616 rows
-sunat skills get endpoints   # the SUNAT endpoints behind each command
-sunat skills list            # everything this version ships
+sunat-cli skills get schemas     # field specs for RHE and F616 rows
+sunat-cli skills get endpoints   # the SUNAT endpoints behind each command
+sunat-cli skills list            # everything this version ships
 ```

--- a/packages/cli/src/skills/schemas.md
+++ b/packages/cli/src/skills/schemas.md
@@ -51,10 +51,10 @@ Portal: Nueva Plataforma (e-menu.sunat.gob.pe/cl-ti-itmenu2/), menu code 55.1.3.
 There is no payload: the amount comes from a row loaded into the form.
 
 ```bash
-sunat f616 declarar periodo 2026-03
-sunat f616 declarar ingreso --fecha 03/03/2026 --monto 21016 --cliente "CLIENTE EJEMPLO"
-sunat f616 declarar estado     # casilla 355 has the figure SUNAT will charge
-sunat f616 declarar bandeja
+sunat-cli f616 declarar periodo 2026-03
+sunat-cli f616 declarar ingreso --fecha 03/03/2026 --monto 21016 --cliente "CLIENTE EJEMPLO"
+sunat-cli f616 declarar estado     # casilla 355 has the figure SUNAT will charge
+sunat-cli f616 declarar bandeja
 ```
 
 Income row fields (the modal's, not a CLI schema):

--- a/packages/cli/src/sunat-rest/padron-local.ts
+++ b/packages/cli/src/sunat-rest/padron-local.ts
@@ -199,7 +199,7 @@ export function parsePadronLine(line: string): PadronEntry | null {
 export async function lookupRuc(ruc: string): Promise<PadronEntry | null> {
 	if (!/^\d{11}$/.test(ruc)) return null;
 	if (!existsSync(TXT_PATH)) {
-		throw new Error("Padrón not synced. Run: sunat padron sync");
+		throw new Error("Padrón not synced. Run: sunat-cli padron sync");
 	}
 
 	return new Promise((resolve, reject) => {
@@ -242,7 +242,7 @@ export async function lookupRucBatch(rucs: string[]): Promise<Map<string, Padron
 		}
 	}
 	if (wanted.size === 0) return result;
-	if (!existsSync(TXT_PATH)) throw new Error("Padrón not synced. Run: sunat padron sync");
+	if (!existsSync(TXT_PATH)) throw new Error("Padrón not synced. Run: sunat-cli padron sync");
 
 	return new Promise((resolve, reject) => {
 		const stream = createReadStream(TXT_PATH, { encoding: "latin1" });

--- a/packages/cli/src/sunat-rest/ruc-portal.ts
+++ b/packages/cli/src/sunat-rest/ruc-portal.ts
@@ -5,7 +5,7 @@
  * + reCAPTCHA in 2024. Workaround: drive a real Chrome via agent-browser,
  * fill the form, parse the rendered detail page.
  *
- * For BATCH lookups always prefer `sunat padron ruc/batch` (offline,
+ * For BATCH lookups always prefer `sunat-cli padron ruc/batch` (offline,
  * instantaneous after sync). This module is for ad-hoc single-RUC checks
  * when you don't want to download the 370MB padrón.
  */

--- a/packages/cli/tests/e2e/audit-cli.test.ts
+++ b/packages/cli/tests/e2e/audit-cli.test.ts
@@ -37,7 +37,7 @@ afterEach(() => {
 	}
 });
 
-describe("sunat audit — E2E", () => {
+describe("sunat-cli audit — E2E", () => {
 	test("audit compact archives old active months and keeps recent monthly logs active", async () => {
 		const home = createTempHome();
 		const auditDir = join(home, ".sunat", "audit");

--- a/packages/cli/tests/e2e/cpe-cli.test.ts
+++ b/packages/cli/tests/e2e/cpe-cli.test.ts
@@ -58,7 +58,7 @@ afterEach(() => {
 	}
 });
 
-describe("sunat cpe — E2E", () => {
+describe("sunat-cli cpe — E2E", () => {
 	test("--help lists cpe namespace", async () => {
 		const result = await runCli(["--help"]);
 		expect(result.exitCode).toBe(0);

--- a/packages/cli/tests/unit/parsers.test.ts
+++ b/packages/cli/tests/unit/parsers.test.ts
@@ -71,7 +71,7 @@ describe("parseFacturaInput", () => {
 			parseFacturaInput("{}");
 			expect.unreachable();
 		} catch (err) {
-			expect((err as Error).message).toContain("sunat schema cpe-factura");
+			expect((err as Error).message).toContain("sunat-cli schema cpe-factura");
 		}
 	});
 
@@ -129,7 +129,7 @@ describe("parseNotaInput", () => {
 			parseNotaInput(JSON.stringify(broken));
 			expect.unreachable();
 		} catch (err) {
-			expect((err as Error).message).toContain("sunat schema cpe-nota-credito");
+			expect((err as Error).message).toContain("sunat-cli schema cpe-nota-credito");
 		}
 	});
 


### PR DESCRIPTION
154 prose references named a bare `sunat` command that does not exist, across 22 files including `src/schemas/*.json`, `src/skills/core.md` and error-message hints. Copying any of them gives `command not found`.

It matters most in the schemas and the agent manual, since those are what an agent reads to learn the surface. `src/skills/core.md` and `skills/sunat-cli/SKILL.md` both claimed a global install provides `sunat`; it provides `sunat-cli`, and that was the root claim the whole convention rested on.

Scope was verified rather than assumed: every replaced line is a runnable command invocation. Preserved untouched are `SUNAT_RUC`/`SUNAT_USER`/`SUNAT_PASSWORD`, `~/.sunat`, the agent-browser session id, and the tipo-cambio source discriminator.

Two assertions in `parsers.test.ts` were updated. Both assert that an error hint names a runnable schema command, which is exactly the string corrected here, so they failed by design. Each still asserts the full command via `toContain`; no matcher was widened.

Pairs with the program-name fix: until both land, hints say `sunat-cli` while the Usage line says `sunat`.

385 pass.