### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/sunat-cli",
-	"version": "0.8.1",
+	"version": "0.9.0",
 	"description": "Agent-first CLI for SUNAT tax automation",
 	"module": "bin/sunat.ts",
 	"type": "module",


### PR DESCRIPTION
Bumps to 0.9.0, which is what triggers the release workflow.

Ships the eight audit fixes merged in #62 through #69.

Minor and not patch: `nextSteps` now writes to stderr on six commands that previously wrote nothing there. stdout is byte-identical on every command, verified by sha256 before and after, so a consumer reading only stdout sees no change.

396 tests pass on main.