### PR TITLE
fix(release): push the tag with git, the way trx does

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,11 @@ jobs:
       run:
         working-directory: packages/cli
     steps:
+      # Credentials are kept so the tag can be pushed with git, the way it works
+      # in the sibling trx pipeline. The gh api call this replaces failed three
+      # times across releases with no diagnostic, always after a successful
+      # publish, leaving the package on npm with no tag and no release.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-        with:
-          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
@@ -141,14 +143,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.local }}
         run: |
-          tag_sha=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/v$VERSION" --jq .object.sha 2>/dev/null || true)
-          if [ -z "$tag_sha" ]; then
-            gh api "repos/$GITHUB_REPOSITORY/git/refs" \
-              --method POST \
-              -f ref="refs/tags/v$VERSION" \
-              -f sha="$GITHUB_SHA" >/dev/null
+          # git push, not gh api. The API call this replaces died three times
+          # across releases in under a second with no gh diagnostic, always
+          # after publish had already succeeded. The sibling trx pipeline
+          # pushes the tag with git and has not failed here, so this follows
+          # the mechanism that works rather than a guess at why the other did
+          # not. Idempotent: a tag already pointing at this commit is fine, one
+          # pointing elsewhere is a real conflict and must stop the run.
+          existing=$(git ls-remote --tags origin "refs/tags/v$VERSION" | awk '{print $1}')
+          if [ -n "$existing" ]; then
+            test "$existing" = "$GITHUB_SHA"
           else
-            test "$tag_sha" = "$GITHUB_SHA"
+            git tag "v$VERSION"
+            git push origin "v$VERSION"
           fi
           if ! gh release view "v$VERSION" >/dev/null 2>&1; then
             gh release create "v$VERSION" "$GITHUB_WORKSPACE/.release/crafter-sunat-cli-$VERSION.tgz" --title "v$VERSION" --generate-notes --verify-tag


### PR DESCRIPTION
The 0.9.0 release published to npm and then died in the tag step in 0.35s with no `gh` diagnostic in the log, leaving the package with no tag and no GitHub release. **Third time this step has failed after a successful publish.**

## What was ruled out, with evidence

- **Not permissions.** The run log shows `Contents: write`.
- **Not tag protection.** The repo has no rulesets; `/tags/protection` returns 404.
- **Not the script.** The same step succeeded for 0.8.1 ninety minutes earlier.
- **Not the API call.** Running it by hand created the tag on the first attempt.

The cause of the `gh api` failure remains unidentified. It printed nothing, which is itself the problem: the call's output went nowhere and `bash -e` aborted before anything reached the log.

## What this changes, and why

Rather than guess at a cause, this adopts the mechanism that already works in the same portfolio. The sibling `trx` pipeline does:

```
git tag "v$VERSION"
git push origin "v$VERSION"
```

and has not failed at this step. The reason sunat-cli could not do that is `persist-credentials: false` on checkout, which strips the git credentials and is what forced the API call in the first place.

So: keep the credentials, push the tag with git.

The check stays idempotent. A tag already pointing at this commit passes; one pointing elsewhere is a real conflict and stops the run.

## Trade-off worth naming

`persist-credentials: false` is a hardening measure: it keeps a token out of `.git/config` where a later step could read it. Dropping it is a real reduction, mitigated by every step in this job being first-party or a pinned action. If that trade is unwanted, the alternative is a PAT or App token for the API call, which moves the secret rather than removing it.

v0.9.0's tag and release were created by hand after the failure; the release tarball and the npm tarball hash identically (`3706e51abb789c94...`).