### PR TITLE
feat: human output round 2, and one place that decides the format

### DIFF
--- a/packages/cli/bin/sunat.ts
+++ b/packages/cli/bin/sunat.ts
@@ -15,8 +15,21 @@ import { createSireCommand } from "../src/commands/sire/index.ts";
 import { createSkillsCommand } from "../src/commands/skills.ts";
 import { createTipoCambioCommand } from "../src/commands/tipo-cambio.ts";
 import { createWhoamiCommand } from "../src/commands/whoami.ts";
+import { printBanner } from "../src/utils/banner.ts";
 
 const program = new Command();
+
+/**
+ * The banner belongs to the two screens a person reads before running anything:
+ * bare invoke and `--help`. Putting it on every command would tax each
+ * invocation of a CLI whose main caller is an agent.
+ */
+function wantsBanner(argv: string[]): boolean {
+	const args = argv.slice(2);
+	if (args.length === 0) return true;
+	if (args.some((a) => a === "-o" || a === "--output" || a.startsWith("--output="))) return false;
+	return args.every((a) => a === "help" || a === "-h" || a === "--help");
+}
 
 program
 	.name("sunat-cli")
@@ -44,5 +57,9 @@ program.addCommand(createRentaCommand());
 program.addCommand(createSireCommand());
 program.addCommand(createTipoCambioCommand());
 program.addCommand(createAuditCommand());
+
+if (wantsBanner(process.argv)) {
+	printBanner({ version: pkg.version, tagline: "Agent-first CLI for SUNAT tax automation" });
+}
 
 program.parse();

--- a/packages/cli/src/commands/api/index.ts
+++ b/packages/cli/src/commands/api/index.ts
@@ -1,8 +1,27 @@
 import { Command } from "commander";
 import { getApiCredentials, getCredentials } from "../../data/config.ts";
-import { output, outputError } from "../../utils/output.ts";
+import { formatDuration } from "../../utils/dates.ts";
+import { isHumanFormat, output, outputError } from "../../utils/output.ts";
+import { bold, dim, maskSecret, muted, ok } from "../../utils/style.ts";
 
 const TOKEN_URL = "https://api-seguridad.sunat.gob.pe/v1/clientessol";
+
+/**
+ * The question this command answers is "do I have a working token, and for how
+ * long", not "show me the credential". The full bearer stays out of the human
+ * branch: on a TTY it can be shoulder-surfed or land in a screenshot, and a
+ * reader gets nothing from sixty opaque characters that a masked preview does
+ * not already give them.
+ *
+ * Machine mode is unchanged and deliberately carries no token either, which has
+ * been the contract since the privacy hardening in #52.
+ */
+export function renderTokenStatus(status: { tokenType: string; expiresIn: number; preview: string }): string[] {
+	return [
+		`${ok("●")} API credentials valid  ${muted(`${status.tokenType} token`)}`,
+		`  ${dim("expires in")} ${bold(formatDuration(status.expiresIn))}  ${dim(`· ${status.preview}`)}`,
+	];
+}
 
 export function createApiCommand(): Command {
 	const api = new Command("api").description("SUNAT REST API operations");
@@ -35,7 +54,19 @@ export function createApiCommand(): Command {
 
 				const data = await response.json();
 				if (!data.access_token) throw new Error("Token response did not contain an access token.");
-				output(format, { json: { authenticated: true, tokenType: data.token_type, expiresIn: data.expires_in } });
+
+				const json = { authenticated: true, tokenType: data.token_type, expiresIn: data.expires_in };
+				if (!isHumanFormat(format)) {
+					output("json", { json });
+					return;
+				}
+				for (const line of renderTokenStatus({
+					tokenType: data.token_type,
+					expiresIn: data.expires_in,
+					preview: maskSecret(String(data.access_token)),
+				})) {
+					console.log(line);
+				}
 			} catch (err) {
 				outputError(err instanceof Error ? err.message : String(err), format);
 			}

--- a/packages/cli/src/commands/cpe/index.ts
+++ b/packages/cli/src/commands/cpe/index.ts
@@ -3,13 +3,15 @@ import { clearQueueForEmisor, enqueueBoleta, listQueueDates, readQueue } from ".
 import { buildCatalogCoverageReport, hasCatalogWarnings } from "../../cpe/catalogos/index.ts";
 import { loadCpeConfig, resolveCpeAuditContext, resolveCpeContext, saveCpeConfig } from "../../cpe/config.ts";
 import { getDriver } from "../../cpe/drivers/index.ts";
-import type { CpeDriverName } from "../../cpe/drivers/types.ts";
+import type { CpeDriverName, CpeMode, DoctorCheck, DoctorReport, DriverInfo } from "../../cpe/drivers/types.ts";
 import { parseFacturaInput, parseNotaInput } from "../../cpe/parsers.ts";
 import { boletaRequiresIndividualSubmission } from "../../cpe/ubl/boleta.ts";
 import { audit } from "../../data/audit.ts";
 import { loadConfig } from "../../data/config.ts";
 import { resolveSecret } from "../../data/keychain.ts";
-import { output, outputError } from "../../utils/output.ts";
+import { emitNextSteps, type NextStep } from "../../utils/next-steps.ts";
+import { isHumanFormat, output, outputError } from "../../utils/output.ts";
+import { bold, danger, dim, info, muted, ok as okColor, padVisible, visibleWidth } from "../../utils/style.ts";
 
 type Format = "json" | "table" | "auto";
 
@@ -43,6 +45,65 @@ function getFormat(cmd: unknown): Format {
 	return findOption<Format>(cmd, "output") ?? "auto";
 }
 
+/**
+ * True when the human branch should render. The root normalizes `auto` to
+ * `table` or `json` before an action runs, so `auto` only survives here when a
+ * subcommand is invoked outside that hook.
+ */
+function isHuman(format: Format): boolean {
+	return isHumanFormat(format);
+}
+
+/**
+ * A driver name a reader can act on. `mock` never reaches SUNAT, so a person
+ * reading "healthy" needs to know the answer came from memory rather than the
+ * wire; that distinction is the whole value of the line.
+ */
+export function describeDriver(d: DriverInfo): string {
+	return d.name === "mock" ? "nothing is sent to SUNAT" : `${d.mode === "prod" ? "live" : "sandbox"} endpoint`;
+}
+
+/**
+ * `prod` is the state a reader must not miss, so it takes `info`: it departs
+ * from the safe default. `danger` stays reserved for errors, and a sandbox is
+ * not an error.
+ */
+export function styleMode(mode: CpeMode): string {
+	return mode === "prod" ? info(mode) : muted(mode);
+}
+
+/**
+ * Only read-only commands are emitted. An emitted command is an executable
+ * promise, and nothing here may point a reader at a write path against SUNAT.
+ */
+export function doctorNextSteps(report: DoctorReport): NextStep[] {
+	if (report.ok) {
+		return report.driver.name === "mock"
+			? [{ command: "sunat-cli cpe doctor --driver sunat-direct", description: "check the driver that reaches SUNAT" }]
+			: [];
+	}
+	const failed = new Set(report.checks.filter((c) => !c.ok).map((c) => c.name));
+	const steps: NextStep[] = [];
+	if (failed.has("config_resolved") || failed.has("cert_file_exists") || failed.has("cert_loaded")) {
+		steps.push({ command: "sunat-cli cpe profile list", description: "the emisor or certificate is not resolving" });
+	}
+	if (failed.has("stale_pendings")) {
+		steps.push({ command: "sunat-cli audit list", description: "review the submissions left pending" });
+	}
+	return steps;
+}
+
+/**
+ * One check line: glyph and colour agree, so the eye never has to resolve a
+ * green cross. A failed check in a health report IS the error state, which is
+ * the one thing `danger` is for.
+ */
+export function formatCheck(check: DoctorCheck, labelWidth: number): string {
+	const glyph = check.ok ? okColor("✓") : danger("✗");
+	const name = padVisible(check.ok ? check.name : bold(check.name), labelWidth);
+	return `  ${glyph} ${name}${check.detail ? `  ${muted(check.detail)}` : ""}`;
+}
+
 function getDriverName(cmd: unknown): CpeDriverName | undefined {
 	return findOption<CpeDriverName>(cmd, "driver");
 }
@@ -73,7 +134,34 @@ export function createCpeCommand(): Command {
 			try {
 				const driver = getDriver(getDriverName(cmd));
 				const report = await driver.doctor();
-				output(format, { json: report });
+
+				if (!isHuman(format)) {
+					output(format, { json: report });
+					return;
+				}
+
+				// The question is "is my driver working", not "what does the report
+				// object contain", so the verdict leads and the checks support it.
+				const failed = report.checks.filter((c) => !c.ok);
+				console.log(
+					report.ok
+						? `${okColor("●")} ${bold(report.driver.name)} driver healthy  ${muted(`${report.checks.length} checks passed`)}`
+						: `${danger("●")} ${bold(report.driver.name)} driver ${danger("unhealthy")}  ${muted(
+								`${failed.length} of ${report.checks.length} checks failed`,
+							)}`,
+				);
+				console.log(
+					dim(`  ${styleMode(report.driver.mode)} · v${report.driver.version} · ${describeDriver(report.driver)}`),
+				);
+				console.log();
+
+				// Failures first: a reader scanning a health check is looking for what
+				// broke, and burying it under passing rows costs them the scan.
+				const ordered = [...failed, ...report.checks.filter((c) => c.ok)];
+				const labelWidth = Math.max(...ordered.map((c) => visibleWidth(c.name)));
+				for (const check of ordered) console.log(formatCheck(check, labelWidth));
+
+				emitNextSteps(doctorNextSteps(report), format);
 			} catch (err) {
 				outputError(err instanceof Error ? err.message : String(err), format);
 			}
@@ -86,7 +174,27 @@ export function createCpeCommand(): Command {
 			const format = getFormat(cmd);
 			try {
 				const driver = getDriver(getDriverName(cmd));
-				output(format, { json: driver.info() });
+				const d = driver.info();
+
+				if (!isHuman(format)) {
+					output(format, { json: d });
+					return;
+				}
+
+				console.log(`${bold(d.name)} ${muted(`v${d.version}`)}  ${styleMode(d.mode)}`);
+				console.log(dim(`  ${describeDriver(d)}`));
+				console.log();
+				// A flag only says something when it is true: a row reading "no" for
+				// every driver is vertical repetition, and the machine mode still
+				// carries both fields for a caller that wants them.
+				const rows: Array<[string, string]> = [];
+				if (d.endpoint) rows.push(["Endpoint", d.endpoint]);
+				if (d.requiresJava) rows.push(["Requires", "Java on PATH"]);
+				if (d.acreditadoOse) rows.push(["OSE", "acreditado"]);
+				const width = rows.length > 0 ? Math.max(...rows.map(([k]) => k.length)) : 0;
+				for (const [k, v] of rows) console.log(`  ${dim(padVisible(k, width))}  ${v}`);
+
+				emitNextSteps([{ command: "sunat-cli cpe doctor", description: "verify this driver is working" }], format);
 			} catch (err) {
 				outputError(err instanceof Error ? err.message : String(err), format);
 			}

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -15,7 +15,7 @@ interface LoginOpts {
 
 async function getOrPromptCredentials(
 	opts: LoginOpts,
-	isTTY: boolean,
+	canPrompt: boolean,
 ): Promise<{ ruc: string; usuario: string; password: string }> {
 	const config = loadConfig();
 	let ruc = opts.ruc || process.env.SUNAT_RUC || config.ruc;
@@ -26,7 +26,7 @@ async function getOrPromptCredentials(
 		return { ruc, usuario, password };
 	}
 
-	if (!isTTY) {
+	if (!canPrompt) {
 		throw new Error(
 			"Missing credentials. Pass --ruc and --user, set SUNAT_RUC, SUNAT_USER and SUNAT_PASSWORD, or store SUNAT_PASSWORD with sunat-cli keychain set",
 		);
@@ -94,9 +94,10 @@ export function createLoginCommand(): Command {
 		.action(async (opts: LoginOpts, cmd) => {
 			const format = cmd.parent?.opts().output || "table";
 			const portal = opts.nuevaPlataforma ? "nueva-plataforma" : "sol";
-			const isTTY = process.stdout.isTTY && format !== "json";
+			// Whether we may ask the operator a question, not how we print the answer.
+			const canPrompt = process.stdout.isTTY && format !== "json";
 			try {
-				const creds = await getOrPromptCredentials(opts, isTTY);
+				const creds = await getOrPromptCredentials(opts, canPrompt);
 				if (opts.nuevaPlataforma) {
 					await loginNuevaPlataforma(creds);
 				} else {
@@ -106,7 +107,7 @@ export function createLoginCommand(): Command {
 				outputSuccess(`Logged in to ${portal === "sol" ? "SOL (RHE)" : "Nueva Plataforma (F616)"}`, format);
 
 				if (!isSkillInstalled()) {
-					await installSkill(isTTY);
+					await installSkill(canPrompt);
 				}
 			} catch (err) {
 				const msg = err instanceof Error ? err.message : String(err);

--- a/packages/cli/src/commands/padron/index.ts
+++ b/packages/cli/src/commands/padron/index.ts
@@ -1,9 +1,9 @@
 import { Command } from "commander";
+import { audit } from "../../data/audit.ts";
 import type { PadronEntry } from "../../sunat-rest/padron-local.ts";
 import { isStale, loadMeta, lookupRuc, lookupRucBatch, syncPadron } from "../../sunat-rest/padron-local.ts";
-import { audit } from "../../data/audit.ts";
 import { emitNextSteps } from "../../utils/next-steps.ts";
-import { output, outputError } from "../../utils/output.ts";
+import { isHumanFormat, output, outputError } from "../../utils/output.ts";
 import { bold, dim, muted, ok, warn } from "../../utils/style.ts";
 
 type Format = "json" | "table" | "auto";
@@ -24,7 +24,7 @@ function getFormat(cmd: Command): Format {
  * subcommand is invoked outside that hook.
  */
 function isHuman(format: Format): boolean {
-	return format === "table" || (format === "auto" && Boolean(process.stdout.isTTY));
+	return isHumanFormat(format);
 }
 
 function fmtBytes(n: number): string {
@@ -205,7 +205,9 @@ export function createPadronCommand(): Command {
 
 	padron
 		.command("ruc")
-		.description("Lookup a single RUC in the local padrón. Streaming scan — slow first call (~5-15s on 600MB), instant after. T0.")
+		.description(
+			"Lookup a single RUC in the local padrón. Streaming scan — slow first call (~5-15s on 600MB), instant after. T0.",
+		)
 		.argument("<ruc>", "11-digit RUC to lookup")
 		.action(async (ruc, opts, cmd) => {
 			const format = getFormat(cmd);
@@ -276,7 +278,12 @@ export function createPadronCommand(): Command {
 
 				const rucs = input
 					.split("\n")
-					.map((l) => l.trim().split(/[,;\t]/)[0].trim())
+					.map((l) =>
+						l
+							.trim()
+							.split(/[,;\t]/)[0]
+							.trim(),
+					)
 					.filter((l) => /^\d{11}$/.test(l));
 
 				if (rucs.length === 0) {

--- a/packages/cli/src/commands/renta/index.ts
+++ b/packages/cli/src/commands/renta/index.ts
@@ -216,7 +216,7 @@ export function createRentaCommand(): Command {
 				}
 
 				console.log(`${bold("Declaración")} ${dim("F709")} ${opts.ejercicio}   ${muted(`RUC ${decl.numRuc}`)}`);
-				console.log(dim(`periodo ${decl.perTri} · hash ${decl.valHash.slice(0, 12)}…`));
+				console.log(dim(`periodo ${decl.perTri} · hash ${truncateVisible(decl.valHash, 13)}`));
 				console.log();
 				const sections: Array<[string, unknown]> = [
 					["Generales", decl.declaracion.generales],

--- a/packages/cli/src/commands/sire/index.ts
+++ b/packages/cli/src/commands/sire/index.ts
@@ -18,7 +18,9 @@ import {
 	sireCredentials,
 	sireUpload,
 } from "../../sunat-rest/sire.ts";
-import { output, outputError } from "../../utils/output.ts";
+import { emitNextSteps } from "../../utils/next-steps.ts";
+import { isHumanFormat, output, outputError } from "../../utils/output.ts";
+import { bold, dim, muted, padVisible, visibleWidth, warn } from "../../utils/style.ts";
 
 type Format = "json" | "table" | "auto";
 
@@ -30,6 +32,35 @@ function getFormat(cmd: Command): Format {
 		parent = parent.parent;
 	}
 	return "auto";
+}
+
+/**
+ * True when the human branch should render. The root normalizes `auto` to
+ * `table` or `json` before an action runs, so `auto` only survives here when a
+ * subcommand is invoked outside that hook.
+ */
+function isHuman(format: Format): boolean {
+	return isHumanFormat(format);
+}
+
+/**
+ * `202504` is a key, not a date. A reader scanning a column of six-digit blobs
+ * has to segment each one; the separator does it once, here.
+ */
+export function fmtPeriodo(perTributario: string): string {
+	return /^\d{6}$/.test(perTributario) ? `${perTributario.slice(0, 4)}-${perTributario.slice(4, 6)}` : perTributario;
+}
+
+/**
+ * SUNAT sends `desEstado` as its own human description, and the `codEstado`
+ * catalogue is not documented in this repo: the type comment says "01
+ * presentado" while the captured fixture pairs "01" with "Pendiente". Printing
+ * the server's word avoids inventing a mapping that would read backwards, and
+ * the machine contract still carries `codEstado` for a caller that has the
+ * catalogue.
+ */
+export function fmtEstado(desEstado: string | undefined): string {
+	return desEstado?.trim() ? desEstado.trim() : muted("sin estado");
 }
 
 function resolveSireCreds(): ReturnType<typeof sireCredentials> {
@@ -52,7 +83,57 @@ function bookCommand(libroAlias: "ventas" | "compras", codLibro: CodLibro): Comm
 			try {
 				const creds = resolveSireCreds();
 				const ejercicios = await listarPeriodos(codLibro, creds);
-				output(format, { json: { codLibro, ejercicios } });
+
+				if (!isHuman(format)) {
+					output(format, { json: { codLibro, ejercicios } });
+					return;
+				}
+
+				const total = ejercicios.reduce((n, e) => n + (e.lisPeriodos?.length ?? 0), 0);
+
+				// An empty list is an answer, and the raw `[]` was not one: SIRE is
+				// only assigned to taxpayers obligated to keep the book, so nothing
+				// here usually means "not enrolled" rather than "nothing happened".
+				if (total === 0) {
+					console.log(`${warn("○")} No ${bold(longName)} periods available`);
+					console.log(
+						dim("  SUNAT lists no periodos for this RUC, which normally means the book is not assigned to it."),
+					);
+					return;
+				}
+
+				console.log(
+					`${bold(String(total))} periodo${total === 1 ? "" : "s"} ${muted(
+						`· ${longName} · ${ejercicios.length} ejercicio${ejercicios.length === 1 ? "" : "s"}`,
+					)}`,
+				);
+
+				// The ejercicio is a heading, not a column: repeating "2025" down
+				// twelve rows is twelve chances to read it and no information after
+				// the first.
+				for (const ej of ejercicios) {
+					const periodos = ej.lisPeriodos ?? [];
+					console.log();
+					console.log(`${bold(ej.numEjercicio)}  ${muted(fmtEstado(ej.desEstado))}`);
+					const width = Math.max(0, ...periodos.map((p) => visibleWidth(fmtPeriodo(p.perTributario))));
+					for (const p of periodos) {
+						console.log(`  ${padVisible(fmtPeriodo(p.perTributario), width)}  ${fmtEstado(p.desEstado)}`);
+					}
+				}
+
+				const latest = ejercicios.flatMap((e) => e.lisPeriodos ?? []).map((p) => p.perTributario);
+				const target = latest.sort().at(-1);
+				emitNextSteps(
+					target
+						? [
+								{
+									command: `sunat-cli sire ${libroAlias} propuesta --periodo ${target}`,
+									description: "download SUNAT's proposal for the most recent periodo",
+								},
+							]
+						: [],
+					format,
+				);
 			} catch (err) {
 				outputError(err instanceof Error ? err.message : String(err), format);
 			}

--- a/packages/cli/src/utils/banner.ts
+++ b/packages/cli/src/utils/banner.ts
@@ -1,0 +1,89 @@
+/**
+ * The ASCII wordmark shown on bare invoke and `--help`.
+ *
+ * Three constraints decide everything here:
+ *
+ * 1. STDERR ONLY. stdout is data territory. A banner on stdout ends up inside
+ *    `sunat-cli ... > out.json` and breaks the parse, which is the whole reason
+ *    a machine-readable CLI keeps the streams apart.
+ * 2. TTY ONLY. Piped output, machine mode, and CI get nothing at all.
+ * 3. NO_COLOR removes the drawing, not just the colour. The wordmark IS the
+ *    colour: rendered as plain blocks it is a wall of glyphs a screen reader
+ *    reads one by one. Under NO_COLOR it degrades to a single plain line, which
+ *    is the same information without the ink.
+ *
+ * Pattern taken from cligentic's `foundation/banner`, reimplemented against
+ * this repo's own `style.ts` rather than installed: a published output contract
+ * outranks a shared block.
+ */
+
+import { shouldColor } from "./style.ts";
+
+/**
+ * The wordmark, on the 5-line grid cligentic's GLYPHS use.
+ *
+ * "-" has no glyph in that font. It was added by hand on the same grid: a
+ * single bar on the middle row, one cell narrower than a letter so the two
+ * words stay visually separate.
+ */
+const WORDMARK: readonly string[] = [
+	" ████ █   █ █   █   █   █████        ████ █     █████",
+	"█     █   █ ██  █  █ █    █         █     █       █  ",
+	" ███  █   █ █ █ █ █████   █   ████  █     █       █  ",
+	"    █ █   █ █  ██ █   █   █         █     █       █  ",
+	"████   ███  █   █ █   █   █          ████ █████ █████",
+];
+
+/** SUNAT's institutional red, faded down the block. */
+const GRADIENT: readonly [string, string] = ["#D8232A", "#7A1418"];
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+	const h = hex.replace("#", "");
+	return {
+		r: Number.parseInt(h.slice(0, 2), 16),
+		g: Number.parseInt(h.slice(2, 4), 16),
+		b: Number.parseInt(h.slice(4, 6), 16),
+	};
+}
+
+export type BannerOptions = {
+	version: string;
+	tagline?: string;
+};
+
+/**
+ * Build the banner as lines. Separated from the writing so a test can assert
+ * the content without a terminal, and so the caller cannot accidentally send it
+ * to the wrong stream.
+ */
+export function buildBanner(opts: BannerOptions, color: boolean): string[] {
+	const meta = [`v${opts.version}`, opts.tagline].filter(Boolean).join("  ·  ");
+
+	if (!color) return ["", `  sunat-cli ${meta}`, ""];
+
+	const from = hexToRgb(GRADIENT[0]);
+	const to = hexToRgb(GRADIENT[1]);
+	const lines = WORDMARK.map((line, i) => {
+		const t = WORDMARK.length > 1 ? i / (WORDMARK.length - 1) : 0;
+		const r = Math.round(from.r + (to.r - from.r) * t);
+		const g = Math.round(from.g + (to.g - from.g) * t);
+		const b = Math.round(from.b + (to.b - from.b) * t);
+		return `  \x1b[38;2;${r};${g};${b}m${line}\x1b[0m`;
+	});
+
+	return ["", ...lines, `  \x1b[2m${meta}\x1b[0m`, ""];
+}
+
+/**
+ * Write the banner to stderr when a person is watching, and never otherwise.
+ *
+ * `process.stderr.isTTY` is the gate rather than stdout's: the banner is only
+ * legible if the stream it lands on is a terminal, and a caller redirecting
+ * stdout to a file still deserves to see it.
+ */
+export function printBanner(opts: BannerOptions): void {
+	if (!process.stderr.isTTY) return;
+	for (const line of buildBanner(opts, shouldColor())) {
+		process.stderr.write(`${line}\n`);
+	}
+}

--- a/packages/cli/src/utils/dates.ts
+++ b/packages/cli/src/utils/dates.ts
@@ -12,6 +12,26 @@ export function periodoToSUNAT(periodo: string): string {
 	return `${month}-${year}`;
 }
 
+/**
+ * Seconds into the phrase a person reads off a clock.
+ *
+ * An OAuth `expires_in` answers the protocol's question, not the reader's:
+ * "3600" has to be divided before it means "this hour". Rounds down, because a
+ * token shown as having a minute left while it expires in fifty seconds is the
+ * direction of error worth avoiding.
+ */
+export function formatDuration(seconds: number): string {
+	if (!Number.isFinite(seconds) || seconds <= 0) return "expired";
+
+	const total = Math.floor(seconds);
+	const hours = Math.floor(total / 3600);
+	const minutes = Math.floor((total % 3600) / 60);
+
+	if (hours > 0) return minutes > 0 ? `${hours}h ${minutes}min` : `${hours}h`;
+	if (minutes > 0) return `${minutes}min`;
+	return `${total}s`;
+}
+
 export function expandPeriodoRange(range: string): string[] {
 	const [start, end] = range.split("..");
 	if (!start || !end) throw new Error(`Invalid range: "${range}". Use YYYY-MM..YYYY-MM`);

--- a/packages/cli/src/utils/next-steps.ts
+++ b/packages/cli/src/utils/next-steps.ts
@@ -1,4 +1,4 @@
-import type { OutputFormat } from "./output.ts";
+import { type OutputFormat, resolveFormat } from "./output.ts";
 import { bold, dim, info, muted } from "./style.ts";
 
 /**
@@ -36,7 +36,7 @@ export type NextStep = {
 export function emitNextSteps(steps: NextStep[], format: OutputFormat): void {
 	if (steps.length === 0) return;
 
-	const resolved = format === "auto" ? (process.stdout.isTTY ? "table" : "json") : format;
+	const resolved = resolveFormat(format);
 
 	if (resolved === "json") {
 		for (const step of steps) {

--- a/packages/cli/src/utils/output.ts
+++ b/packages/cli/src/utils/output.ts
@@ -37,11 +37,31 @@ export function outputTable(headers: string[], rows: string[][]): void {
 	}
 }
 
+/**
+ * The one place that decides machine versus human output.
+ *
+ * `auto` resolves from the TTY, so a piped or captured run is machine-readable
+ * without the caller passing a flag. Every site that needs the answer imports
+ * this rather than reading `isTTY` again: three copies of the rule had drifted
+ * apart, and the command that forgets is the one an agent hits.
+ *
+ * A TTY check guarding a prompt is a different question and does not belong
+ * here.
+ */
+export function resolveFormat(format: OutputFormat): "json" | "table" {
+	if (format === "auto") return process.stdout.isTTY ? "table" : "json";
+	return format;
+}
+
+export function isHumanFormat(format: OutputFormat): boolean {
+	return resolveFormat(format) === "table";
+}
+
 export function output(
 	format: OutputFormat,
 	data: { json: unknown; table?: { headers: string[]; rows: string[][] } },
 ): void {
-	const resolvedFormat = format === "auto" ? (process.stdout.isTTY ? "table" : "json") : format;
+	const resolvedFormat = resolveFormat(format);
 
 	if (resolvedFormat === "json") {
 		if (Array.isArray(data.json)) {

--- a/packages/cli/src/utils/skill.ts
+++ b/packages/cli/src/utils/skill.ts
@@ -10,8 +10,8 @@ export function isSkillInstalled(): boolean {
 	return existsSync(SKILL_MD);
 }
 
-export async function installSkill(isTTY: boolean): Promise<boolean> {
-	if (!isTTY) return false;
+export async function installSkill(canPrompt: boolean): Promise<boolean> {
+	if (!canPrompt) return false;
 
 	const install = await p.confirm({
 		message: "Install Claude Code skill? (lets AI agents use sunat-cli)",

--- a/packages/cli/src/utils/style.ts
+++ b/packages/cli/src/utils/style.ts
@@ -72,6 +72,19 @@ export function padStartVisible(s: string, width: number): string {
 	return pad > 0 ? " ".repeat(pad) + s : s;
 }
 
+/**
+ * A preview of a secret that identifies it without disclosing it.
+ *
+ * Keeps the head and tail so a reader can tell two credentials apart, and
+ * spends a fixed-width ellipsis on the middle so the output never leaks the
+ * length of what it hides. Anything too short to mask safely renders fully
+ * masked rather than partially revealed.
+ */
+export function maskSecret(secret: string, visible = 4): string {
+	if (secret.length <= visible * 2) return "•".repeat(8);
+	return `${secret.slice(0, visible)}…${secret.slice(-visible)}`;
+}
+
 export function truncateVisible(s: string, width: number): string {
 	if (visibleWidth(s) <= width) return s;
 	if (width <= 1) return stripAnsi(s).slice(0, width);

--- a/packages/cli/tests/e2e/banner-cli.test.ts
+++ b/packages/cli/tests/e2e/banner-cli.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+const CLI = join(import.meta.dir, "..", "..", "bin", "sunat.ts");
+
+/**
+ * Bun.spawn gives the child pipes rather than a terminal, so every run here is
+ * the non-TTY case. That is exactly the case worth locking: it is the one a
+ * redirect or an agent produces, and the one a banner would corrupt.
+ *
+ * The TTY branch cannot be reached from a test runner and is verified by hand
+ * with `script -q /dev/null`.
+ */
+async function run(args: string[]): Promise<{ stdout: string; stderr: string }> {
+	const proc = Bun.spawn(["bun", "run", CLI, ...args], { stdout: "pipe", stderr: "pipe" });
+	const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+	await proc.exited;
+	return { stdout, stderr };
+}
+
+describe("banner stream boundary", () => {
+	test("--help writes no banner to stdout when stdout is a pipe", async () => {
+		const { stdout } = await run(["--help"]);
+
+		expect(stdout).not.toContain("█");
+		expect(stdout).not.toContain("sunat-cli v");
+		expect(stdout.startsWith("Usage:")).toBe(true);
+	});
+
+	test("piped help carries no ANSI at all", async () => {
+		const { stdout } = await run(["--help"]);
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: asserting the absence of escapes is the point
+		expect(stdout).not.toMatch(/\x1b\[/);
+	});
+
+	test("bare invoke keeps stdout free of the wordmark", async () => {
+		const { stdout } = await run([]);
+		expect(stdout).not.toContain("█");
+	});
+
+	test("machine mode prints no banner on either stream", async () => {
+		const { stdout, stderr } = await run(["-o", "json", "--help"]);
+		expect(stdout).not.toContain("█");
+		expect(stderr).not.toContain("█");
+	});
+});

--- a/packages/cli/tests/unit/api-token.test.ts
+++ b/packages/cli/tests/unit/api-token.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { renderTokenStatus } from "../../src/commands/api/index.ts";
+import { formatDuration } from "../../src/utils/dates.ts";
+import { maskSecret, setColorOverride, stripAnsi } from "../../src/utils/style.ts";
+
+/**
+ * `api token` mints a real credential against SUNAT, so it is never executed
+ * here. These assert the render function and its two helpers directly, which is
+ * where the disclosure decision actually lives.
+ */
+
+// Built at runtime rather than pasted as a literal. The value is synthetic (a
+// sample RUC and the word "signature"), but a hardcoded JWT-shaped string trips
+// the repo's secret scanner, and turning that gate off to keep a fixture would
+// be the wrong trade.
+const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+const JWT = `${b64({ alg: "HS256", typ: "JWT" })}.${b64({ sub: "20601234567" })}.sIgNaTuRe_Xyz9`;
+
+describe("maskSecret", () => {
+	test("keeps a head and tail so two credentials stay distinguishable", () => {
+		expect(maskSecret(JWT)).toBe("eyJh…Xyz9");
+	});
+
+	test("never contains the secret it masks", () => {
+		expect(maskSecret(JWT)).not.toContain(JWT);
+		expect(JWT).not.toContain(maskSecret(JWT));
+	});
+
+	test("hides the length of the secret", () => {
+		const short = maskSecret(`${JWT}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`);
+		expect(maskSecret(JWT).length).toBe(short.length);
+	});
+
+	test("fully masks a secret too short to preview safely", () => {
+		expect(maskSecret("abcd1234")).toBe("••••••••");
+		expect(maskSecret("")).toBe("••••••••");
+	});
+});
+
+describe("formatDuration", () => {
+	test("renders an OAuth hour as a phrase, not a second count", () => {
+		expect(formatDuration(3600)).toBe("1h");
+	});
+
+	test("carries minutes alongside hours", () => {
+		expect(formatDuration(5400)).toBe("1h 30min");
+	});
+
+	test("rounds down so a token never looks fresher than it is", () => {
+		expect(formatDuration(119)).toBe("1min");
+	});
+
+	test("reports sub-minute and dead tokens plainly", () => {
+		expect(formatDuration(45)).toBe("45s");
+		expect(formatDuration(0)).toBe("expired");
+		expect(formatDuration(-10)).toBe("expired");
+		expect(formatDuration(Number.NaN)).toBe("expired");
+	});
+});
+
+describe("renderTokenStatus", () => {
+	const status = { tokenType: "Bearer", expiresIn: 3600, preview: maskSecret(JWT) };
+
+	test("answers expiry in a readable form and never prints the credential", () => {
+		const text = stripAnsi(renderTokenStatus(status).join("\n"));
+		expect(text).toContain("API credentials valid");
+		expect(text).toContain("Bearer");
+		expect(text).toContain("expires in 1h");
+		expect(text).toContain("eyJh…Xyz9");
+		expect(text).not.toContain(JWT);
+		expect(text).not.toContain("3600");
+	});
+
+	test("carries no ANSI once colour is off", () => {
+		setColorOverride(false);
+		try {
+			const text = renderTokenStatus(status).join("\n");
+			expect(text).toBe(stripAnsi(text));
+		} finally {
+			setColorOverride(null);
+		}
+	});
+
+	test("styles the human branch when colour is on, without leaking the token", () => {
+		setColorOverride(true);
+		try {
+			const text = renderTokenStatus(status).join("\n");
+			expect(text).not.toBe(stripAnsi(text));
+			expect(text).not.toContain(JWT);
+		} finally {
+			setColorOverride(null);
+		}
+	});
+});

--- a/packages/cli/tests/unit/banner.test.ts
+++ b/packages/cli/tests/unit/banner.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { buildBanner } from "../../src/utils/banner.ts";
+import { stripAnsi } from "../../src/utils/style.ts";
+
+const OPTS = { version: "0.9.0", tagline: "Agent-first CLI for SUNAT tax automation" };
+
+describe("buildBanner", () => {
+	test("draws the wordmark on a uniform grid", () => {
+		const glyphs = buildBanner(OPTS, true)
+			.filter((l) => l.includes("█"))
+			.map((l) => [...stripAnsi(l).slice(2)].length);
+
+		expect(glyphs).toHaveLength(5);
+		expect(new Set(glyphs).size).toBe(1);
+	});
+
+	test("keeps the hyphen on the middle row only, since the font has no glyph for it", () => {
+		const rows = buildBanner(OPTS, true)
+			.filter((l) => l.includes("█"))
+			.map((l) => [...stripAnsi(l).slice(2)]);
+
+		const width = rows[0]?.length ?? 0;
+		const middleOnly: number[] = [];
+		for (let c = 0; c < width; c++) {
+			const ink = rows.map((r) => r[c] === "█");
+			if (ink[2] && !ink[0] && !ink[1] && !ink[3] && !ink[4]) middleOnly.push(c);
+		}
+
+		expect(middleOnly).toEqual([14, 30, 31, 32, 33]);
+	});
+
+	test("carries the version and tagline", () => {
+		const text = stripAnsi(buildBanner(OPTS, true).join("\n"));
+		expect(text).toContain("v0.9.0");
+		expect(text).toContain("Agent-first CLI for SUNAT tax automation");
+	});
+
+	test("degrades to a single plain line without colour", () => {
+		const lines = buildBanner(OPTS, false);
+		const text = lines.join("\n");
+
+		expect(text).toBe(stripAnsi(text));
+		expect(text).not.toContain("█");
+		expect(text).toContain("sunat-cli v0.9.0");
+	});
+
+	test("emits colour only when asked", () => {
+		const colored = buildBanner(OPTS, true).join("\n");
+		expect(colored).not.toBe(stripAnsi(colored));
+	});
+});

--- a/packages/cli/tests/unit/cpe-human-view.test.ts
+++ b/packages/cli/tests/unit/cpe-human-view.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import { describeDriver, doctorNextSteps, formatCheck, styleMode } from "../../src/commands/cpe/index.ts";
+import type { DoctorReport, DriverInfo } from "../../src/cpe/drivers/types.ts";
+import { setColorOverride, stripAnsi, visibleWidth } from "../../src/utils/style.ts";
+
+const DANGER = "38;5;203";
+const OK = "38;5;78";
+const INFO = "38;5;75";
+const MUTED = "38;5;245";
+
+const mockInfo: DriverInfo = { name: "mock", mode: "sandbox", version: "0.1.0", endpoint: "memory://" };
+
+function report(over: Partial<DoctorReport>): DoctorReport {
+	return { driver: mockInfo, ok: true, checks: [], ...over };
+}
+
+describe("cpe driver description", () => {
+	// A reader told "healthy" needs to know the answer came from memory rather
+	// than the wire, which is the only thing that separates the two drivers here.
+	test("mock says nothing is sent, real drivers name the endpoint they reach", () => {
+		expect(describeDriver(mockInfo)).toBe("nothing is sent to SUNAT");
+		expect(describeDriver({ ...mockInfo, name: "sunat-direct" })).toBe("sandbox endpoint");
+		expect(describeDriver({ ...mockInfo, name: "sunat-direct", mode: "prod" })).toBe("live endpoint");
+	});
+
+	test("prod is the state a reader must not miss, and sandbox is not an error", () => {
+		setColorOverride(true);
+		expect(styleMode("prod")).toContain(INFO);
+		expect(styleMode("sandbox")).toContain(MUTED);
+		// A sandbox is a safe default, not a failure: danger stays for errors.
+		expect(styleMode("sandbox")).not.toContain(DANGER);
+		expect(styleMode("prod")).not.toContain(DANGER);
+		setColorOverride(null);
+	});
+});
+
+describe("cpe doctor check lines", () => {
+	test("glyph and colour agree, so a passing check never reads as a failure", () => {
+		setColorOverride(true);
+		const pass = formatCheck({ name: "driver_loaded", ok: true }, 13);
+		const fail = formatCheck({ name: "cert_loaded", ok: false }, 13);
+		expect(pass).toContain("✓");
+		expect(pass).toContain(OK);
+		expect(pass).not.toContain(DANGER);
+		// A failed check in a health report is the error state, which is what
+		// danger exists for.
+		expect(fail).toContain("✗");
+		expect(fail).toContain(DANGER);
+		expect(fail).not.toContain(OK);
+		setColorOverride(null);
+	});
+
+	// The bug this guards: padding a styled label with `.length` over-pads by the
+	// size of the escapes, so the detail column drifts once colour is on.
+	test("check names stay aligned by visible width even when styled", () => {
+		setColorOverride(true);
+		const width = 13;
+		const lines = [
+			formatCheck({ name: "driver_loaded", ok: true, detail: "@" }, width),
+			formatCheck({ name: "no_network", ok: false, detail: "@" }, width),
+		];
+		const detailColumns = lines.map((l) => stripAnsi(l).indexOf("@"));
+		expect(detailColumns[0]).toBe(detailColumns[1]);
+		// And the styled string really is longer than what the terminal draws,
+		// which is exactly why `.length` would have been wrong.
+		expect(lines[1].length).toBeGreaterThan(visibleWidth(lines[1]));
+		setColorOverride(null);
+	});
+
+	test("styling leaves the words intact so NO_COLOR loses nothing but colour", () => {
+		setColorOverride(true);
+		expect(stripAnsi(formatCheck({ name: "cert_loaded", ok: false, detail: "expired" }, 11))).toBe(
+			"  ✗ cert_loaded  expired",
+		);
+		setColorOverride(false);
+		expect(formatCheck({ name: "cert_loaded", ok: true }, 0)).toBe("  ✓ cert_loaded");
+		setColorOverride(null);
+	});
+});
+
+describe("cpe doctor next steps", () => {
+	// An emitted command is an executable promise, so a healthy report that has
+	// nothing safe to suggest emits nothing at all.
+	test("a healthy real driver suggests nothing", () => {
+		expect(doctorNextSteps(report({ driver: { ...mockInfo, name: "sunat-direct" }, ok: true }))).toEqual([]);
+	});
+
+	test("a healthy mock points at the driver that actually reaches SUNAT", () => {
+		const steps = doctorNextSteps(report({ ok: true }));
+		expect(steps).toHaveLength(1);
+		expect(steps[0].command).toBe("sunat-cli cpe doctor --driver sunat-direct");
+	});
+
+	test("a config or certificate failure points at the profile that resolves it", () => {
+		const steps = doctorNextSteps(
+			report({ ok: false, checks: [{ name: "cert_loaded", ok: false, detail: "expired" }] }),
+		);
+		expect(steps.map((s) => s.command)).toEqual(["sunat-cli cpe profile list"]);
+	});
+
+	test("stale pendings point at the audit log, and only read-only commands are emitted", () => {
+		const steps = doctorNextSteps(
+			report({
+				ok: false,
+				checks: [
+					{ name: "config_resolved", ok: false },
+					{ name: "stale_pendings", ok: false },
+				],
+			}),
+		);
+		expect(steps.map((s) => s.command)).toEqual(["sunat-cli cpe profile list", "sunat-cli audit list"]);
+		// Nothing emitted here may file, send, or declare anything.
+		for (const s of steps) expect(s.command).not.toMatch(/emit|send|declarar|--yes|sync/);
+	});
+});

--- a/packages/cli/tests/unit/sire-human-view.test.ts
+++ b/packages/cli/tests/unit/sire-human-view.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { fmtEstado, fmtPeriodo } from "../../src/commands/sire/index.ts";
+import { setColorOverride, stripAnsi } from "../../src/utils/style.ts";
+
+const DANGER = "38;5;203";
+const MUTED = "38;5;245";
+
+describe("sire periodo formatting", () => {
+	// `202504` is a key, not a date: the separator does the segmenting once.
+	test("a six-digit periodo reads as year and month", () => {
+		expect(fmtPeriodo("202504")).toBe("2025-04");
+		expect(fmtPeriodo("202412")).toBe("2024-12");
+	});
+
+	test("anything that is not six digits is passed through untouched", () => {
+		expect(fmtPeriodo("2025")).toBe("2025");
+		expect(fmtPeriodo("")).toBe("");
+		expect(fmtPeriodo("20250412")).toBe("20250412");
+	});
+
+	// SUNAT's own `desEstado` is printed verbatim: the `codEstado` catalogue is
+	// contradictory in this repo (the type says "01 presentado", the captured
+	// fixture pairs "01" with "Pendiente"), so mapping it would risk a label that
+	// reads backwards.
+	test("the server's own description is printed verbatim", () => {
+		setColorOverride(false);
+		expect(fmtEstado("Presentado")).toBe("Presentado");
+		expect(fmtEstado("  Pendiente  ")).toBe("Pendiente");
+		setColorOverride(null);
+	});
+
+	test("a missing estado degrades to muted context, never to a red error", () => {
+		setColorOverride(true);
+		expect(fmtEstado(undefined)).toContain(MUTED);
+		expect(fmtEstado(undefined)).not.toContain(DANGER);
+		expect(stripAnsi(fmtEstado(""))).toBe("sin estado");
+		setColorOverride(null);
+	});
+});


### PR DESCRIPTION
Second pass against the cli-audit findings. Mechanical failures go from 9 to 3, and the three that remain are open decisions rather than pending work.

## What landed

**One resolver for machine versus human output.** Five files decided it independently, each rereading `process.stdout.isTTY` and reimplementing the same rule. `resolveFormat` and `isHumanFormat` now live in `utils/output.ts` and every consumer imports them. Three of those five reappeared during this round, on branches cut before the resolver existed, which is the drift the check exists to catch.

**A banner**, TTY-only and on stderr. stdout carries zero banner bytes and zero control characters, verified by redirecting only stdout while stderr stays a terminal. Under `NO_COLOR` it degrades to a single text line: the wordmark is the color, and as plain blocks it is a wall of glyphs for a screen reader.

**Human views for `cpe info`, `cpe doctor`, `sire ventas periodos`, `sire compras periodos`.** All four printed byte-identical JSON on a terminal and through a pipe. `cpe doctor` now answers "is my driver working" with per-check state and a runnable next step.

**`api token` reads for a person**: state, token type, expiry in a readable form, masked preview. The mask is applied where the secret exists, so the guarantee holds if the shape changes.

**The last hand-rolled truncation** goes through `truncateVisible`.

**`login`'s `isTTY` renamed to `canPrompt`.** It gated whether the operator could be asked a question, never how the answer was printed.

## Machine contract unchanged

Verified per command by comparing `-o json` output before and after. No difference on any of them.

## Tests

396 to 429 pass, 0 fail. Nothing removed or weakened.

## Corrected along the way

The audit finding for `api token` said it printed the full bearer JWT. That was true of the published 0.8.0 binary and false of `main`, where `e77fa3e` had already removed it. An audit finding names a version, and this one named the wrong one.

## Still open, and they are decisions rather than defects

- `--json <payload>` as an input flag on `f616` and `rhe`: renaming breaks callers
- the `bun` shebang: two checks fail on it and they are the same call about the build target