### PR TITLE
release: 0.10.0, installable without Bun and with --json meaning output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,18 @@ jobs:
         run: npm run build
         working-directory: packages/website
 
+      # npm pack and npm publish both run with --ignore-scripts below, so a
+      # prepublishOnly hook would never fire. The build has to be its own step
+      # or the tarball ships a bin that does not exist.
+      - name: Build CLI
+        run: bun run build
+
+      - name: Verify the built bin runs without bun
+        run: |
+          head -1 dist/sunat.js | grep -qx '#!/usr/bin/env node'
+          env PATH=/usr/bin:/bin node dist/sunat.js --help | grep -q "cpe"
+          test "$(env PATH=/usr/bin:/bin node dist/sunat.js --version)" = "${{ steps.version.outputs.local }}"
+
       - name: Build release tarball
         env:
           VERSION: ${{ steps.version.outputs.local }}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,9 +25,13 @@
 		"cdp"
 	],
 	"bin": {
-		"sunat-cli": "bin/sunat.ts"
+		"sunat-cli": "dist/sunat.js"
+	},
+	"engines": {
+		"node": ">=24"
 	},
 	"files": [
+		"dist",
 		"bin",
 		"src",
 		"!src/**/RESEARCH.md",
@@ -38,6 +42,7 @@
 	],
 	"scripts": {
 		"dev": "bun run bin/sunat.ts",
+		"build": "bun run scripts/build.ts",
 		"check": "biome check --write .",
 		"test": "bun test",
 		"test:unit": "bun test tests/unit",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/sunat-cli",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"description": "Agent-first CLI for SUNAT tax automation",
 	"module": "bin/sunat.ts",
 	"type": "module",

--- a/packages/cli/scripts/build.ts
+++ b/packages/cli/scripts/build.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env bun
+import { rmSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Builds the artifact that npm installs.
+ *
+ * Bun is the dev runtime, but the published bin has to run for someone who only
+ * has Node, so the entry is bundled with `--target=node` and re-shebanged.
+ *
+ * Dependencies stay external (`--packages=external`): they are real npm deps
+ * that the installer already resolves, and bundling them would ship duplicates
+ * of code npm is about to install anyway.
+ */
+
+const PKG_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const ENTRY = join(PKG_ROOT, "bin", "sunat.ts");
+const OUT_DIR = join(PKG_ROOT, "dist");
+const OUT_FILE = join(OUT_DIR, "sunat.js");
+const NODE_SHEBANG = "#!/usr/bin/env node";
+
+rmSync(OUT_DIR, { recursive: true, force: true });
+
+const result = await Bun.build({
+	entrypoints: [ENTRY],
+	outdir: OUT_DIR,
+	target: "node",
+	packages: "external",
+	naming: "sunat.js",
+});
+
+if (!result.success) {
+	for (const log of result.logs) console.error(log);
+	process.exit(1);
+}
+
+// Bun hoists the entry's own `#!/usr/bin/env bun` to line 1 of the bundle, so a
+// `--banner` shebang would land underneath it and Node would parse the second
+// one as a syntax error. Replacing line 1 is what actually leaves one shebang.
+const bundled = await readFile(OUT_FILE, "utf-8");
+const lines = bundled.split("\n");
+if (lines[0]?.startsWith("#!")) {
+	lines[0] = NODE_SHEBANG;
+} else {
+	lines.unshift(NODE_SHEBANG);
+}
+
+const output = lines.join("\n");
+if (!output.startsWith(`${NODE_SHEBANG}\n`)) {
+	console.error("build: expected the artifact to start with the node shebang");
+	process.exit(1);
+}
+if (output.includes("#!/usr/bin/env bun")) {
+	console.error("build: a bun shebang survived into the artifact");
+	process.exit(1);
+}
+
+await writeFile(OUT_FILE, output, { mode: 0o755 });
+
+console.log(`built ${OUT_FILE}`);

--- a/packages/cli/skills/sunat-cli/SKILL.md
+++ b/packages/cli/skills/sunat-cli/SKILL.md
@@ -44,7 +44,7 @@ Linux stores secrets through `secret-tool` / libsecret.
 
 ```bash
 # Emit single RHE
-sunat-cli rhe emit --json '{
+sunat-cli rhe emit --params '{
   "empresa": "Cliente Ejemplo",
   "tipoDoc": "SIN DOCUMENTO",
   "descripcion": "Servicios de desarrollo de software",
@@ -54,7 +54,7 @@ sunat-cli rhe emit --json '{
 }'
 
 # Preview without submitting
-sunat-cli rhe emit --json '...' --dry-run
+sunat-cli rhe emit --params '...' --dry-run
 
 # Batch from CSV
 sunat-cli rhe emit --batch recibos.csv
@@ -78,12 +78,12 @@ Key rules:
 
 ```bash
 # Single month
-sunat-cli f616 declare --json '{
+sunat-cli f616 declare --params '{
   "periodo": "2026-03"
 }'
 
 # Preview
-sunat-cli f616 declare --json '...' --dry-run
+sunat-cli f616 declare --params '...' --dry-run
 
 # Batch multiple months
 sunat-cli f616 declare --batch --months "2025-03..2026-02"
@@ -518,13 +518,13 @@ not as an error.
 
 **Monthly routine (4ta categoria)**:
 1. `sunat-cli login --nueva-plataforma`
-2. `sunat-cli f616 declare --json '{"periodo":"2026-03"}' --dry-run`
+2. `sunat-cli f616 declare --params '{"periodo":"2026-03"}' --dry-run`
 3. Review dry-run output
 4. Remove `--dry-run` to submit
 
 **Emit an RHE**:
 1. `sunat-cli login`
-2. `sunat-cli rhe emit --json '{"empresa":"Cliente Ejemplo","tipoDoc":"SIN DOCUMENTO","descripcion":"Servicios de desarrollo de software - Marzo 2026","monto":6700,"moneda":"USD","medioPago":"TRANSFERENCIA"}'`
+2. `sunat-cli rhe emit --params '{"empresa":"Cliente Ejemplo","tipoDoc":"SIN DOCUMENTO","descripcion":"Servicios de desarrollo de software - Marzo 2026","monto":6700,"moneda":"USD","medioPago":"TRANSFERENCIA"}'`
 3. `sunat-cli rhe verify --month 2026-03`
 
 ## Error Handling

--- a/packages/cli/src/commands/f616/index.ts
+++ b/packages/cli/src/commands/f616/index.ts
@@ -3,6 +3,7 @@ import { audit } from "../../data/audit.ts";
 import { ensurePlataformaToken } from "../../plataforma/ensure-token.ts";
 import { obtenerListaOficios, obtenerPeriodo } from "../../plataforma/f616-api.ts";
 import { expandPeriodoRange } from "../../utils/dates.ts";
+import { resolveParams } from "../../utils/deprecation.ts";
 import { output, outputError } from "../../utils/output.ts";
 import { validatePeriodo } from "../../validation/input.ts";
 import { declareF616, ensureNuevaPlataformaAndF616, type F616Input, navigateToF616 } from "../../workflows/f616.ts";
@@ -14,7 +15,8 @@ export function createF616Command(): Command {
 	f616
 		.command("declare")
 		.description("File F616 monthly tax declaration")
-		.option("--json <payload>", "JSON payload with F616 data")
+		.option("--params <json>", "JSON payload (see: sunat-cli schema f616)")
+		.option("--json <payload>", "Deprecated alias for --params, will be removed in a later 0.x release")
 		.option("--batch", "Process multiple months")
 		.option("--months <range>", "Month range (e.g. 2025-03..2026-02)")
 		.option("--dry-run", "Preview without submitting")
@@ -23,6 +25,7 @@ export function createF616Command(): Command {
 		.action(async (opts, cmd) => {
 			const format = cmd.parent?.parent?.opts().output || "auto";
 			const dryRun = opts.dryRun || false;
+			const params = resolveParams(opts, "--params", "--json", format);
 
 			try {
 				if (opts.batch && opts.months) {
@@ -46,8 +49,8 @@ export function createF616Command(): Command {
 						await navigateToF616();
 						await new Promise((r) => setTimeout(r, 2000));
 					}
-				} else if (opts.json) {
-					const raw = JSON.parse(opts.json);
+				} else if (params) {
+					const raw = JSON.parse(params);
 					const periodo = validatePeriodo(String(raw.periodo));
 					const input: F616Input = {
 						periodo,
@@ -68,7 +71,7 @@ export function createF616Command(): Command {
 					audit({ command: "f616 declare", args: { ...input }, result: "success", details: { ...result } });
 					output(format, { json: { success: true, ...result } });
 				} else {
-					outputError("Provide --json or --batch --months. Use 'sunat-cli schema f616' to see fields.", format);
+					outputError("Provide --params or --batch --months. Use 'sunat-cli schema f616' to see fields.", format);
 				}
 			} catch (err) {
 				const msg = err instanceof Error ? err.message : String(err);

--- a/packages/cli/src/commands/rhe/index.ts
+++ b/packages/cli/src/commands/rhe/index.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import { ensureSOLSession } from "../../browser/auth.ts";
 import { audit } from "../../data/audit.ts";
 import { getCredentials } from "../../data/config.ts";
+import { resolveParams } from "../../utils/deprecation.ts";
 import { output, outputError } from "../../utils/output.ts";
 import {
 	sanitizePath,
@@ -20,12 +21,14 @@ export function createRheCommand(): Command {
 	rhe
 		.command("emit")
 		.description("Emit an RHE via SUNAT SOL")
-		.option("--json <payload>", "JSON payload with RHE data")
+		.option("--params <json>", "JSON payload (see: sunat-cli schema rhe)")
+		.option("--json <payload>", "Deprecated alias for --params, will be removed in a later 0.x release")
 		.option("--batch <file>", "CSV file with multiple RHEs")
 		.option("--dry-run", "Preview without submitting")
 		.action(async (opts, cmd) => {
 			const format = cmd.parent?.parent?.opts().output || "auto";
 			const dryRun = opts.dryRun || false;
+			const params = resolveParams(opts, "--params", "--json", format);
 
 			try {
 				if (opts.batch) {
@@ -51,8 +54,8 @@ export function createRheCommand(): Command {
 							output(format, { json: { success: true, ...result } });
 						}
 					}
-				} else if (opts.json) {
-					const raw = JSON.parse(opts.json);
+				} else if (params) {
+					const raw = JSON.parse(params);
 					const input = validateRHEInput(raw);
 
 					if (dryRun) {
@@ -71,7 +74,7 @@ export function createRheCommand(): Command {
 						output(format, { json: { success: true, ...result } });
 					}
 				} else {
-					outputError("Provide --json or --batch. Use 'sunat-cli schema rhe' to see fields.", format);
+					outputError("Provide --params or --batch. Use 'sunat-cli schema rhe' to see fields.", format);
 				}
 			} catch (err) {
 				const msg = err instanceof Error ? err.message : String(err);

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -1,10 +1,11 @@
 import { Command } from "commander";
 import { readFileSync } from "fs";
-import { dirname, join } from "path";
+import { join } from "path";
 import { getCpeCatalogosSchema } from "../cpe/catalogos/index.ts";
 import { outputJSON } from "../utils/output.ts";
+import { packageDataDir } from "../utils/package-data.ts";
 
-const SCHEMAS_DIR = join(dirname(import.meta.dir), "schemas");
+const SCHEMAS_DIR = packageDataDir("schemas");
 
 const AVAILABLE_SCHEMAS = [
 	"rhe",

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -1,9 +1,9 @@
 import { Command } from "commander";
 import { existsSync, readdirSync, readFileSync } from "fs";
-import { dirname, join } from "path";
-import { fileURLToPath } from "url";
+import { join } from "path";
 import { emitNextSteps } from "../utils/next-steps.ts";
 import { output, outputError } from "../utils/output.ts";
+import { packageDataDir } from "../utils/package-data.ts";
 import { truncateVisible } from "../utils/style.ts";
 
 /**
@@ -17,7 +17,7 @@ import { truncateVisible } from "../utils/style.ts";
  * Mismo patrón que `agent-browser skills get core`.
  */
 
-const SKILLS_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "skills");
+const SKILLS_DIR = packageDataDir("skills");
 
 /**
  * Si el usuario pidió JSON explícitamente.

--- a/packages/cli/src/skills/core.md
+++ b/packages/cli/src/skills/core.md
@@ -27,7 +27,7 @@ RUC and usuario are saved to `~/.sunat/config.json` after first login. Password 
 
 ```bash
 # Emit single RHE
-sunat-cli rhe emit --json '{
+sunat-cli rhe emit --params '{
   "empresa": "Cliente Ejemplo",
   "tipoDoc": "SIN DOCUMENTO",
   "descripcion": "Servicios de desarrollo de software",
@@ -37,7 +37,7 @@ sunat-cli rhe emit --json '{
 }'
 
 # Preview without submitting
-sunat-cli rhe emit --json '...' --dry-run
+sunat-cli rhe emit --params '...' --dry-run
 
 # Batch from CSV
 sunat-cli rhe emit --batch recibos.csv
@@ -145,7 +145,7 @@ form between periods**. Eight periods spanning nine months were filed this way o
 
 **Emit an RHE**:
 1. `sunat-cli login`
-2. `sunat-cli rhe emit --json '{"empresa":"Cliente Ejemplo","tipoDoc":"SIN DOCUMENTO","descripcion":"Servicios de desarrollo de software - Marzo 2026","monto":6700,"moneda":"USD","medioPago":"TRANSFERENCIA","tipoCambio":3.75}' --dry-run`
+2. `sunat-cli rhe emit --params '{"empresa":"Cliente Ejemplo","tipoDoc":"SIN DOCUMENTO","descripcion":"Servicios de desarrollo de software - Marzo 2026","monto":6700,"moneda":"USD","medioPago":"TRANSFERENCIA","tipoCambio":3.75}' --dry-run`
 3. `sunat-cli rhe verify --month 2026-03`
 
 ## Error Handling

--- a/packages/cli/src/utils/deprecation.ts
+++ b/packages/cli/src/utils/deprecation.ts
@@ -1,0 +1,73 @@
+import { type OutputFormat, resolveFormat } from "./output.ts";
+import { dim, warn } from "./style.ts";
+
+/**
+ * `--json` used to mean the input payload here, while almost everywhere else in
+ * the CLI ecosystem it means machine-readable output. An agent that learned the
+ * common convention runs `rhe emit --json` expecting output and gets an error
+ * about a payload it never meant to send. `--params` is the canonical input
+ * name and the `cpe` namespace already used it, so the rename aligns three
+ * namespaces rather than inventing a fourth term.
+ *
+ * The notice goes to stderr for the same reason `emitNextSteps` does: stdout is
+ * the published machine contract, and a caller doing `cmd > out.json` must not
+ * find diagnostics in the file it is about to parse. Every existing byte on
+ * stdout is unchanged.
+ */
+export type DeprecatedFlagNotice = {
+	/** Deprecated spelling, as written on the command line. */
+	deprecated: string;
+	/** Flag the caller should move to. */
+	replacement: string;
+	/** True when both spellings were passed and `replacement` took precedence. */
+	ignored?: boolean;
+};
+
+/**
+ * Never throws and never exits: a deprecation notice must not be able to fail a
+ * command that would otherwise work.
+ */
+export function emitDeprecation(notice: DeprecatedFlagNotice, format: OutputFormat): void {
+	const action = notice.ignored
+		? `${notice.replacement} was also passed and takes precedence, so the ${notice.deprecated} value was ignored`
+		: `use ${notice.replacement} instead`;
+	const message = `${notice.deprecated} is deprecated, ${action}. It will be removed in a later 0.x release.`;
+
+	if (resolveFormat(format) === "json") {
+		process.stderr.write(
+			`${JSON.stringify({
+				type: "deprecation",
+				deprecated: notice.deprecated,
+				replacement: notice.replacement,
+				ignored: notice.ignored ?? false,
+				message,
+			})}\n`,
+		);
+		return;
+	}
+
+	process.stderr.write(`${warn("Deprecated")}  ${message}\n`);
+	process.stderr.write(`${dim(`  Run --help to see the current flags.`)}\n`);
+}
+
+/**
+ * Resolves the input payload from the canonical flag and its deprecated alias,
+ * emitting the notice as a side effect when the alias was used.
+ *
+ * `--params` wins when both are passed. The rule is deterministic and matches
+ * the precedence the `cpe` namespace already documents, and it keeps a caller
+ * mid-migration working: a script that gained `--params` while still passing
+ * `--json` gets the new value rather than an error, and the notice tells them
+ * their `--json` value was dropped.
+ */
+export function resolveParams(
+	opts: { params?: string; json?: string },
+	replacement: string,
+	deprecated: string,
+	format: OutputFormat,
+): string | undefined {
+	if (opts.json !== undefined) {
+		emitDeprecation({ deprecated, replacement, ignored: opts.params !== undefined }, format);
+	}
+	return opts.params ?? opts.json;
+}

--- a/packages/cli/src/utils/package-data.ts
+++ b/packages/cli/src/utils/package-data.ts
@@ -1,0 +1,33 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Locates a data directory that ships inside the package (`src/schemas`,
+ * `src/skills`).
+ *
+ * Two layouts have to resolve from one expression. From source this module sits
+ * in `src/utils/`, so the data is a sibling under `src/`. In the published build
+ * everything is bundled into `dist/sunat.js`, so `import.meta.url` points at
+ * `dist/` and the same data is one level up under `src/`.
+ *
+ * `src/<name>` is tried before a bare `<name>` at every level on purpose: the
+ * package root ships an unrelated top-level `skills/` (the Claude skill stub),
+ * and from `dist/` a bare match would find that one instead of `src/skills`.
+ */
+export function packageDataDir(name: string): string {
+	const start = dirname(fileURLToPath(import.meta.url));
+	let dir = start;
+
+	for (let i = 0; i < 5; i++) {
+		for (const candidate of [join(dir, "src", name), join(dir, name)]) {
+			if (existsSync(candidate)) return candidate;
+		}
+
+		const parent = dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+
+	return join(start, name);
+}

--- a/packages/cli/src/utils/skill.ts
+++ b/packages/cli/src/utils/skill.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import * as p from "@clack/prompts";
@@ -23,20 +24,24 @@ export async function installSkill(canPrompt: boolean): Promise<boolean> {
 	}
 
 	try {
-		const proc = Bun.spawn(["npx", "skills", "add", "Railly/sunat-cli", "-g"], {
-			env: privateChildEnv(process.env, [
-				"HTTPS_PROXY",
-				"HTTP_PROXY",
-				"NO_PROXY",
-				"NPM_CONFIG_CAFILE",
-				"NPM_CONFIG_REGISTRY",
-				"NPM_CONFIG_STRICT_SSL",
-			]),
-			stdin: "inherit",
-			stdout: "inherit",
-			stderr: "inherit",
+		// A missing `npx` surfaces as an async 'error' event here rather than a
+		// throw, so the failure path is a rejected promise instead of the catch
+		// arm reached under a synchronous spawn.
+		const exitCode = await new Promise<number>((resolve, reject) => {
+			const proc = spawn("npx", ["skills", "add", "Railly/sunat-cli", "-g"], {
+				env: privateChildEnv(process.env, [
+					"HTTPS_PROXY",
+					"HTTP_PROXY",
+					"NO_PROXY",
+					"NPM_CONFIG_CAFILE",
+					"NPM_CONFIG_REGISTRY",
+					"NPM_CONFIG_STRICT_SSL",
+				]),
+				stdio: "inherit",
+			});
+			proc.on("error", reject);
+			proc.on("close", (code) => resolve(code ?? 1));
 		});
-		const exitCode = await proc.exited;
 		return exitCode === 0;
 	} catch {
 		p.log.warn("npx skills not available. Install manually: npx skills add Railly/sunat-cli -g");

--- a/packages/cli/src/utils/style.ts
+++ b/packages/cli/src/utils/style.ts
@@ -32,8 +32,24 @@ export function shouldColor(): boolean {
 
 const wrap = (open: string, close: string) => (s: string) => (shouldColor() ? `${open}${s}${close}` : s);
 
-export const bold = wrap("\x1b[1m", "\x1b[22m");
-export const dim = wrap("\x1b[2m", "\x1b[22m");
+/**
+ * Bold and dim share a reset. SGR 22 turns off both, so a bold span nested
+ * inside a dim one ends the dim early and the rest of the line silently loses
+ * its styling. Reopening the outer attribute after each inner reset costs a few
+ * bytes and makes nesting behave the way a caller expects.
+ *
+ * `visibleWidth` strips these the same either way, so column arithmetic is
+ * unaffected.
+ */
+const wrapShared =
+	(open: string, close: string) =>
+	(s: string): string => {
+		if (!shouldColor()) return s;
+		return `${open}${s.replaceAll(close, `${close}${open}`)}${close}`;
+	};
+
+export const bold = wrapShared("\x1b[1m", "\x1b[22m");
+export const dim = wrapShared("\x1b[2m", "\x1b[22m");
 export const italic = wrap("\x1b[3m", "\x1b[23m");
 export const underline = wrap("\x1b[4m", "\x1b[24m");
 

--- a/packages/cli/tests/e2e/params-flag.test.ts
+++ b/packages/cli/tests/e2e/params-flag.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+const CLI = join(import.meta.dir, "..", "..", "bin", "sunat.ts");
+
+/**
+ * Every run here is `--dry-run`. These commands file real tax documents with
+ * SUNAT, and dry-run exercises the flag parsing, which is the whole subject.
+ *
+ * Bun.spawn gives the child pipes rather than a terminal, so `auto` resolves to
+ * json. That is the case an agent or a redirect produces, and the one where
+ * mixing diagnostics into stdout would do real damage.
+ */
+async function run(args: string[]): Promise<{ stdout: string; stderr: string }> {
+	const proc = Bun.spawn(["bun", "run", CLI, ...args], { stdout: "pipe", stderr: "pipe" });
+	const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+	await proc.exited;
+	return { stdout, stderr };
+}
+
+const RHE_PAYLOAD = JSON.stringify({
+	empresa: "Cliente Ejemplo",
+	tipoDoc: "SIN DOCUMENTO",
+	descripcion: "Servicios de desarrollo",
+	monto: 1000,
+	moneda: "PEN",
+	medioPago: "TRANSFERENCIA",
+});
+
+const F616_PAYLOAD = JSON.stringify({ periodo: "2026-03", telefono: "999888777", profesion: "01" });
+
+const CASES = [
+	{ name: "rhe emit", args: ["rhe", "emit"], payload: RHE_PAYLOAD, marker: "would-emit" },
+	{ name: "f616 declare", args: ["f616", "declare"], payload: F616_PAYLOAD, marker: "would-declare" },
+] as const;
+
+describe.each(CASES)("$name input flag", ({ args, payload, marker }) => {
+	test("--params carries the payload", async () => {
+		const { stdout } = await run([...args, "--params", payload, "--dry-run"]);
+		expect(stdout).toContain(marker);
+	});
+
+	test("--params emits no deprecation", async () => {
+		const { stderr } = await run([...args, "--params", payload, "--dry-run"]);
+		expect(stderr).not.toContain("deprecated");
+	});
+
+	test("--json still carries the payload", async () => {
+		const { stdout } = await run([...args, "--json", payload, "--dry-run"]);
+		expect(stdout).toContain(marker);
+	});
+
+	test("--json warns on stderr, naming the replacement", async () => {
+		const { stderr } = await run([...args, "--json", payload, "--dry-run"]);
+		expect(stderr).toContain("--json is deprecated");
+		expect(stderr).toContain("--params");
+	});
+
+	/**
+	 * The point of the rename: a caller redirecting stdout must get the same
+	 * bytes from either spelling, so the notice cannot leak into parsed data.
+	 */
+	test("stdout is byte-identical across both spellings", async () => {
+		const viaParams = await run([...args, "--params", payload, "--dry-run"]);
+		const viaJson = await run([...args, "--json", payload, "--dry-run"]);
+		expect(viaJson.stdout).toBe(viaParams.stdout);
+	});
+
+	test("the deprecation never reaches stdout", async () => {
+		const { stdout } = await run([...args, "--json", payload, "--dry-run"]);
+		expect(stdout).not.toContain("deprecated");
+	});
+
+	/**
+	 * Both passed: --params wins. Deterministic, matches the precedence the cpe
+	 * namespace documents, and keeps a caller mid-migration working.
+	 */
+	test("--params wins when both are passed", async () => {
+		const { stdout } = await run([...args, "--params", payload, "--json", "{}", "--dry-run"]);
+		const viaParams = await run([...args, "--params", payload, "--dry-run"]);
+		expect(stdout).toBe(viaParams.stdout);
+	});
+
+	test("both passed still warns, and says the --json value was ignored", async () => {
+		const { stderr } = await run([...args, "--params", payload, "--json", "{}", "--dry-run"]);
+		expect(stderr).toContain("--json is deprecated");
+		expect(stderr).toContain("ignored");
+	});
+
+	test("--help documents --params and marks --json deprecated", async () => {
+		const { stdout } = await run([...args, "--help"]);
+		expect(stdout).toContain("--params <json>");
+		expect(stdout).toMatch(/--json <payload>\s+Deprecated alias for --params/);
+	});
+
+	test("neither flag points the caller at --params", async () => {
+		const { stderr } = await run([...args, "--dry-run"]);
+		expect(stderr).toContain("--params");
+		expect(stderr).not.toContain("Provide --json");
+	});
+});
+
+describe("deprecation notice shape", () => {
+	test("machine mode emits one parseable JSON line on stderr", async () => {
+		const { stderr } = await run(["-o", "json", "rhe", "emit", "--json", RHE_PAYLOAD, "--dry-run"]);
+		const line = stderr.split("\n").find((l) => l.includes('"deprecation"'));
+		expect(line).toBeDefined();
+
+		const parsed = JSON.parse(line as string);
+		expect(parsed.type).toBe("deprecation");
+		expect(parsed.deprecated).toBe("--json");
+		expect(parsed.replacement).toBe("--params");
+		expect(parsed.ignored).toBe(false);
+	});
+
+	test("machine mode reports ignored when both are passed", async () => {
+		const { stderr } = await run(["-o", "json", "rhe", "emit", "--params", RHE_PAYLOAD, "--json", "{}", "--dry-run"]);
+		const line = stderr.split("\n").find((l) => l.includes('"deprecation"'));
+		expect(JSON.parse(line as string).ignored).toBe(true);
+	});
+
+	test("fires once per invocation, not once per read", async () => {
+		const { stderr } = await run(["rhe", "emit", "--json", RHE_PAYLOAD, "--dry-run"]);
+		expect(stderr.match(/--json is deprecated/g)).toHaveLength(1);
+	});
+});

--- a/packages/cli/tests/unit/style-nesting.test.ts
+++ b/packages/cli/tests/unit/style-nesting.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { bold, dim, setColorOverride, stripAnsi, visibleWidth } from "../../src/utils/style.ts";
+
+describe("nested bold and dim", () => {
+	test("a bold span inside a dim one does not end the dim", () => {
+		setColorOverride(true);
+		try {
+			const out = dim(`before ${bold("BOLD")} after`);
+			expect(out).toContain("\x1b[22m\x1b[2m");
+			expect(out.endsWith("\x1b[22m")).toBe(true);
+		} finally {
+			setColorOverride(null);
+		}
+	});
+
+	test("nesting changes bytes but not the text or its width", () => {
+		setColorOverride(true);
+		try {
+			const out = dim(`before ${bold("BOLD")} after`);
+			expect(stripAnsi(out)).toBe("before BOLD after");
+			expect(visibleWidth(out)).toBe(17);
+		} finally {
+			setColorOverride(null);
+		}
+	});
+
+	test("styling is absent when color is off", () => {
+		setColorOverride(false);
+		try {
+			expect(dim(`before ${bold("BOLD")} after`)).toBe("before BOLD after");
+		} finally {
+			setColorOverride(null);
+		}
+	});
+});


### PR DESCRIPTION
Three changes, and the audit's mechanical failures reach zero.

## Installable without Bun

`bin` pointed at `bin/sunat.ts` with a `#!/usr/bin/env bun` shebang, so anyone installing without Bun got `env: bun: No such file or directory`, a message naming neither cause nor fix. From npm's side the install had succeeded, so the package read as broken rather than under-specified.

The CLI now builds to a Node artifact. Bun stays the development runtime; only what ships changes.

Verified with Bun genuinely unresolvable on PATH:

```
$ env -i PATH=/opt/homebrew/bin:/usr/bin:/bin node dist/sunat.js --help
Usage: sunat-cli [options] [command]
exit=0
```

Control, same environment, old entry point: `env: bun: No such file or directory`. The measurement discriminates.

The tarball was packed, installed into a temp prefix, and run by name with Bun off PATH. `--version`, `--help`, `schema f616`, `padron status`, `whoami`, `cpe info` and `skills list` all exit 0 and are byte-identical to their Bun output on both stdout and stderr.

Two Bun-isms had to go, not one. `Bun.spawn` became `node:child_process`, and `import.meta.dir` in `schema.ts` was invisible to a `Bun.` grep but returns `undefined` under Node, which broke `schema f616` outright. Caught by running the artifact rather than reading it.

The build runs as an explicit workflow step. `npm pack` and `npm publish` both use `--ignore-scripts`, so a `prepublishOnly` hook would never fire, and committing `dist/` invites source and artifact drift.

## `--json` means output

`--json <payload>` meant input on `f616` and `rhe` while `-o json` meant output, so one spelling carried two meanings. An agent that learned the usual convention ran `rhe emit --json` expecting machine output and got an error about data it never meant to send.

The flag is now `--params`, matching what `cpe` already uses, so three namespaces align instead of a fourth term being invented. `--json <payload>` keeps working and warns on stderr; it comes out in a later 0.x.

When both are passed, `--params` wins and the warning says the other value was ignored. That precedence is already documented in this repo at `src/commands/cpe/RESEARCH.md:468`, and a silently dropped value is the surprising part, so it still warns.

## Nested bold and dim

Both close with SGR 22, so a bold span inside a dim one ended the dim early and the rest of the line silently lost its styling. Not live in current output, where the two are always siblings, but one call site away and invisible when it fires: the text stays correct and only the styling is wrong. The regression test was falsified by reverting the fix.

## Why 0.10.0 and not 1.0.0

A breaking change does not need a major in 0.x. Staying on 0.x is the honest signal here: production has never been exercised end to end, so the contract can still move.

## Tests

429 to 455 pass, 0 fail. Nothing removed or weakened.

## Noted, not fixed

- `biome check --write .` reformats 40+ unrelated files on `main`, so `bun run check` cannot serve as a pre-commit gate. Worth a standalone formatting commit.
- `scripts/smoke-sunat.sh` emits a real Factura to SUNAT beta with no dry-run and a name that does not say so.
- `module` in `package.json` still points at the TypeScript source.
