### PR TITLE
fix(release): retry the install check, and tag even when a check fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,13 +164,30 @@ jobs:
             --source-ref refs/heads/main
           workdir=$(mktemp -d)
           cd "$workdir"
-          npm install "@crafter/sunat-cli@$VERSION" --ignore-scripts --registry https://registry.npmjs.org
+          # Retry like the two checks above it. The tarball and the metadata
+          # each get a retry loop, but this install did not, and it is the
+          # slowest thing to propagate: 0.10.0 failed here with ETARGET six
+          # seconds after a successful publish, blocking the tag and release
+          # for a package that was already on npm and correct.
+          for attempt in $(seq 1 15); do
+            if npm install "@crafter/sunat-cli@$VERSION" --ignore-scripts --registry https://registry.npmjs.org; then
+              break
+            fi
+            test "$attempt" != "15"
+            sleep 20
+          done
           test "$(./node_modules/.bin/sunat-cli --version)" = "$VERSION"
           ./node_modules/.bin/sunat-cli --help | grep -q "cpe"
           npm install --ignore-scripts --package-lock-only "@crafter/sunat-cli@$VERSION" --registry https://registry.npmjs.org
           npm audit signatures
 
+      # Runs even when a check above failed. Publish happens before any of
+      # them, so a verification failure leaves the package on npm with no tag
+      # and no release, which is the worst of the three states: 0.9.0 and
+      # 0.10.0 both landed there and both needed finishing by hand. The job
+      # still reports failure, so nothing is hidden.
       - name: Tag and create GitHub release
+        if: always() && steps.version.outputs.publish == 'true'
         working-directory: .
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Two failures on the 0.10.0 release, both after a successful publish.

## The install check did not retry

`Verify published artifact` has three parts. The tarball fetch retries 30 times, the metadata fetch retries 15 times, and the install retried zero times. That last one is the slowest thing to propagate, and it is what failed:

```
npm error code ETARGET
npm error notarget No matching version found for @crafter/sunat-cli@0.10.0.
```

Six seconds after a successful publish, for a package that was already on npm and correct. It now retries on the same schedule as its neighbors.

## The tag step ran only on full success

Publish comes before every verification step, so any failure among them left the package published with no tag and no GitHub release. That is the worst of the three states: npm serves a version that the repository does not acknowledge, and only a human can reconcile it.

It happened on 0.9.0 and again on 0.10.0, and both needed finishing by hand.

The step now runs even after a failure. The job still reports failure, so nothing is hidden; the difference is that the release ends up consistent instead of half-done.

## State of 0.10.0

Already reconciled by hand: tag `v0.10.0` at `4170c11`, release published, and the release tarball hashes identically to the npm one (`3b5cf3e9d5559ce4`). `npm audit signatures` reports verified attestations.

The published package was installed into a clean prefix and run with bun stripped from PATH: `--version` returns 0.10.0 and `schema f616` returns its contract. That is the thing this release existed to make true.