### PR TITLE
chore(deps): take every open Dependabot bump, verified rather than trusted

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,13 +28,19 @@ jobs:
       # in the sibling trx pipeline. The gh api call this replaces failed three
       # times across releases with no diagnostic, always after a successful
       # publish, leaving the package on npm with no tag and no release.
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      # persist-credentials is stated rather than inherited. The tag step pushes
+      # with git, so it needs the credentials, and checkout has changed this
+      # default across major versions. Leaving it implicit means a future bump
+      # silently breaks the release after the package is already published.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: true
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: 1.3.11
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.15.0
           registry-url: https://registry.npmjs.org
@@ -124,7 +130,7 @@ jobs:
           ! grep -E '(^|/)(tests|scripts)/|RESEARCH\.md|CONTEXT\.md|biome\.json|tsconfig\.json' /tmp/sunat-pack-files.txt
 
       - name: Attest release tarball
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: ${{ github.workspace }}/.release/crafter-sunat-cli-${{ steps.version.outputs.local }}.tgz
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.15.0
           registry-url: https://registry.npmjs.org

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
       "dependencies": {
         "@clack/prompts": "^1.1.0",
         "@xmldom/xmldom": "^0.9.10",
-        "commander": "^14.0.3",
+        "commander": "15.0.0",
         "fast-xml-parser": "5.11.0",
         "node-forge": "^1.4.0",
         "xml-crypto": "^6.1.2",
@@ -22,10 +22,10 @@
         "yazl": "^3.3.1",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.14",
+        "@biomejs/biome": "2.5.10",
         "@types/bun": "1.4.0",
         "@types/node-forge": "^1.3.14",
-        "@types/yauzl": "^2.10.3",
+        "@types/yauzl": "^3.4.0",
         "@types/yazl": "^3.3.1",
       },
     },
@@ -37,7 +37,7 @@
         "shiki": "^4.0.2",
       },
       "devDependencies": {
-        "sharp": "0.35.0",
+        "sharp": "0.35.3",
         "vite": "8.2.2",
       },
     },
@@ -90,23 +90,23 @@
 
     "@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.14", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.14", "@biomejs/cli-darwin-x64": "2.4.14", "@biomejs/cli-linux-arm64": "2.4.14", "@biomejs/cli-linux-arm64-musl": "2.4.14", "@biomejs/cli-linux-x64": "2.4.14", "@biomejs/cli-linux-x64-musl": "2.4.14", "@biomejs/cli-win32-arm64": "2.4.14", "@biomejs/cli-win32-x64": "2.4.14" }, "bin": { "biome": "bin/biome" } }, "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.10", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.10", "@biomejs/cli-darwin-x64": "2.5.10", "@biomejs/cli-linux-arm64": "2.5.10", "@biomejs/cli-linux-arm64-musl": "2.5.10", "@biomejs/cli-linux-x64": "2.5.10", "@biomejs/cli-linux-x64-musl": "2.5.10", "@biomejs/cli-win32-arm64": "2.5.10", "@biomejs/cli-win32-x64": "2.5.10" }, "bin": { "biome": "bin/biome" } }, "sha512-WRKXARA3kTuiV5sxqTpobJ/I0MVd4vk3pOL6wnp5az4LntFIhWTj1RWZq3DI9PCEN3lXcqy7p5aqUHzvq8AXyQ=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ItCrxKK6SXVT6flYs0qIuBd4AA3TTTl4d66Re6YI2FuGZnN85NmuYNzkiTJUyYw8qBLv69L5zTUB6uyWd++h3Q=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-yLsPU9pAmtChXDu8vhKAzErqe+LeeYuwuUB2FZMkRitsmdodxsYRa9KHrFispsUHzzOu+9HB3nP/TQxyia+Sjw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-VG8uQW/86a1roLaIFvtIbEigxIdzdJ190oGyg1tV7VYeQtOS+x10sflk7WbuXgw91EtZX5DlIIIej1YqkNLlcg=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-t1QAKZwQJRB4dvgJSgFiQ4BNfNPChg69BNonz854qLVxnjT3UvDzQg9mbkTJRu35ZqU0Rw10A73J8Urgbg2RPw=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.14", "", { "os": "linux", "cpu": "x64" }, "sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.10", "", { "os": "linux", "cpu": "x64" }, "sha512-4O6T0eq2heoHZN0a9UX+rWQoxXEBaKf+lRi2hbsGlHneUz9BWXM76nEWMK7Eeq8gzMxR1khQB6BFpAASpeXqGg=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.14", "", { "os": "linux", "cpu": "x64" }, "sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.10", "", { "os": "linux", "cpu": "x64" }, "sha512-pgDDqp9JybHm2I0KRgzN6i4+lt8xu4iqxUwLzglUMmOmyRTU1AYBGKzh9sNMOtIjah7xoWvKHlLVetvyifzoiQ=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-pxAbxduPO4xq/Cvgaa2lOrs9BB0hEXmmDqfMNP4ZOffGOkUrD1/QGw9UAMpFQpX2P8MqTIIRuQKcmetum4Oa6A=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.14", "", { "os": "win32", "cpu": "x64" }, "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.10", "", { "os": "win32", "cpu": "x64" }, "sha512-M+2dgBsl3lXRiTfgPVc2p3anS4Tocojke4rzFLScZ2Y/wmF+36dRb1iHCLiyGqOzQGyTplZH1HnEYviiAqi3nA=="],
 
     "@bruits/satteri-darwin-arm64": ["@bruits/satteri-darwin-arm64@0.10.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-27KTVl4TJkVahMy/ohyA7qd4938G5UNneFUz/PsScYfpIhj0IVAS23mpcJXdPF44sa6nva198lmV/cKIb2YPyA=="],
 
@@ -326,7 +326,7 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
-    "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
+    "@types/yauzl": ["@types/yauzl@3.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw=="],
 
     "@types/yazl": ["@types/yazl@3.3.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-DIWfCKpsTp6hE5BDBHV3+fIL/bLUF9Bv13iDrWnMlmhQpH67buNvI291ZauQ1xcccxK3FqQ9honnXpq4R8NMuQ=="],
 
@@ -380,7 +380,7 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
-    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+    "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
     "common-ancestor-path": ["common-ancestor-path@2.0.0", "", {}, "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng=="],
 
@@ -694,13 +694,13 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@astrojs/markdown-satteri/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.4", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.3.0", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA=="],
-
     "@bruits/satteri-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
+
+    "find-process/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -253,6 +253,181 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@biomejs/biome": {
+			"version": "2.5.10",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.10.tgz",
+			"integrity": "sha512-WRKXARA3kTuiV5sxqTpobJ/I0MVd4vk3pOL6wnp5az4LntFIhWTj1RWZq3DI9PCEN3lXcqy7p5aqUHzvq8AXyQ==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "2.5.10",
+				"@biomejs/cli-darwin-x64": "2.5.10",
+				"@biomejs/cli-linux-arm64": "2.5.10",
+				"@biomejs/cli-linux-arm64-musl": "2.5.10",
+				"@biomejs/cli-linux-x64": "2.5.10",
+				"@biomejs/cli-linux-x64-musl": "2.5.10",
+				"@biomejs/cli-win32-arm64": "2.5.10",
+				"@biomejs/cli-win32-x64": "2.5.10"
+			}
+		},
+		"node_modules/@biomejs/cli-darwin-arm64": {
+			"version": "2.5.10",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.10.tgz",
+			"integrity": "sha512-ItCrxKK6SXVT6flYs0qIuBd4AA3TTTl4d66Re6YI2FuGZnN85NmuYNzkiTJUyYw8qBLv69L5zTUB6uyWd++h3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-darwin-x64": {
+			"version": "2.5.10",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.10.tgz",
+			"integrity": "sha512-yLsPU9pAmtChXDu8vhKAzErqe+LeeYuwuUB2FZMkRitsmdodxsYRa9KHrFispsUHzzOu+9HB3nP/TQxyia+Sjw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-arm64": {
+			"version": "2.5.10",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.10.tgz",
+			"integrity": "sha512-VG8uQW/86a1roLaIFvtIbEigxIdzdJ190oGyg1tV7VYeQtOS+x10sflk7WbuXgw91EtZX5DlIIIej1YqkNLlcg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-arm64-musl": {
+			"version": "2.5.10",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.10.tgz",
+			"integrity": "sha512-t1QAKZwQJRB4dvgJSgFiQ4BNfNPChg69BNonz854qLVxnjT3UvDzQg9mbkTJRu35ZqU0Rw10A73J8Urgbg2RPw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-x64": {
+			"version": "2.5.10",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.10.tgz",
+			"integrity": "sha512-4O6T0eq2heoHZN0a9UX+rWQoxXEBaKf+lRi2hbsGlHneUz9BWXM76nEWMK7Eeq8gzMxR1khQB6BFpAASpeXqGg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-x64-musl": {
+			"version": "2.5.10",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.10.tgz",
+			"integrity": "sha512-pgDDqp9JybHm2I0KRgzN6i4+lt8xu4iqxUwLzglUMmOmyRTU1AYBGKzh9sNMOtIjah7xoWvKHlLVetvyifzoiQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"libc": [
+				"musl"
+			],
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-win32-arm64": {
+			"version": "2.5.10",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.10.tgz",
+			"integrity": "sha512-pxAbxduPO4xq/Cvgaa2lOrs9BB0hEXmmDqfMNP4ZOffGOkUrD1/QGw9UAMpFQpX2P8MqTIIRuQKcmetum4Oa6A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-win32-x64": {
+			"version": "2.5.10",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.10.tgz",
+			"integrity": "sha512-M+2dgBsl3lXRiTfgPVc2p3anS4Tocojke4rzFLScZ2Y/wmF+36dRb1iHCLiyGqOzQGyTplZH1HnEYviiAqi3nA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
 		"node_modules/@bruits/satteri-darwin-arm64": {
 			"version": "0.10.5",
 			"integrity": "sha512-27KTVl4TJkVahMy/ohyA7qd4938G5UNneFUz/PsScYfpIhj0IVAS23mpcJXdPF44sa6nva198lmV/cKIb2YPyA==",
@@ -1393,8 +1568,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/yauzl": {
-			"version": "2.10.3",
-			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-3.4.0.tgz",
+			"integrity": "sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3598,12 +3774,12 @@
 		},
 		"packages/cli": {
 			"name": "@crafter/sunat-cli",
-			"version": "0.8.1",
+			"version": "0.10.0",
 			"license": "MIT",
 			"dependencies": {
 				"@clack/prompts": "^1.1.0",
 				"@xmldom/xmldom": "^0.9.10",
-				"commander": "^14.0.3",
+				"commander": "15.0.0",
 				"fast-xml-parser": "5.11.0",
 				"node-forge": "^1.4.0",
 				"xml-crypto": "^6.1.2",
@@ -3611,168 +3787,26 @@
 				"yazl": "^3.3.1"
 			},
 			"bin": {
-				"sunat-cli": "bin/sunat.ts"
+				"sunat-cli": "dist/sunat.js"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.4.14",
+				"@biomejs/biome": "2.5.10",
 				"@types/bun": "1.4.0",
 				"@types/node-forge": "^1.3.14",
-				"@types/yauzl": "^2.10.3",
+				"@types/yauzl": "^3.4.0",
 				"@types/yazl": "^3.3.1"
-			}
-		},
-		"packages/cli/node_modules/@biomejs/biome": {
-			"version": "2.4.14",
-			"integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"bin": {
-				"biome": "bin/biome"
 			},
 			"engines": {
-				"node": ">=14.21.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/biome"
-			},
-			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.14",
-				"@biomejs/cli-darwin-x64": "2.4.14",
-				"@biomejs/cli-linux-arm64": "2.4.14",
-				"@biomejs/cli-linux-arm64-musl": "2.4.14",
-				"@biomejs/cli-linux-x64": "2.4.14",
-				"@biomejs/cli-linux-x64-musl": "2.4.14",
-				"@biomejs/cli-win32-arm64": "2.4.14",
-				"@biomejs/cli-win32-x64": "2.4.14"
+				"node": ">=24"
 			}
 		},
-		"packages/cli/node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.4.14",
-			"integrity": "sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
+		"packages/cli/node_modules/commander": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+			"integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+			"license": "MIT",
 			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"packages/cli/node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.4.14",
-			"integrity": "sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"packages/cli/node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.4.14",
-			"integrity": "sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"packages/cli/node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.4.14",
-			"integrity": "sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"packages/cli/node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.4.14",
-			"integrity": "sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"packages/cli/node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.4.14",
-			"integrity": "sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"packages/cli/node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.4.14",
-			"integrity": "sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=14.21.3"
-			}
-		},
-		"packages/cli/node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.4.14",
-			"integrity": "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=14.21.3"
+				"node": ">=22.12.0"
 			}
 		},
 		"packages/website": {
@@ -3783,7 +3817,7 @@
 				"shiki": "^4.0.2"
 			},
 			"devDependencies": {
-				"sharp": "0.35.0",
+				"sharp": "0.35.3",
 				"vite": "8.2.2"
 			}
 		},

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,7 @@
 	"dependencies": {
 		"@clack/prompts": "^1.1.0",
 		"@xmldom/xmldom": "^0.9.10",
-		"commander": "^14.0.3",
+		"commander": "15.0.0",
 		"fast-xml-parser": "5.11.0",
 		"node-forge": "^1.4.0",
 		"xml-crypto": "^6.1.2",
@@ -62,10 +62,10 @@
 		"yazl": "^3.3.1"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.14",
+		"@biomejs/biome": "2.5.10",
 		"@types/bun": "1.4.0",
 		"@types/node-forge": "^1.3.14",
-		"@types/yauzl": "^2.10.3",
+		"@types/yauzl": "^3.4.0",
 		"@types/yazl": "^3.3.1"
 	}
 }

--- a/packages/cli/src/commands/padron/index.ts
+++ b/packages/cli/src/commands/padron/index.ts
@@ -209,7 +209,7 @@ export function createPadronCommand(): Command {
 			"Lookup a single RUC in the local padrón. Streaming scan — slow first call (~5-15s on 600MB), instant after. T0.",
 		)
 		.argument("<ruc>", "11-digit RUC to lookup")
-		.action(async (ruc, opts, cmd) => {
+		.action(async (ruc, _opts, cmd) => {
 			const format = getFormat(cmd);
 			try {
 				if (!/^\d{11}$/.test(ruc)) {
@@ -267,7 +267,7 @@ export function createPadronCommand(): Command {
 			try {
 				let input = "";
 				if (opts.file) {
-					const { readFileSync } = await import("fs");
+					const { readFileSync } = await import("node:fs");
 					input = readFileSync(opts.file, "utf-8");
 				} else if (!process.stdin.isTTY) {
 					input = await new Response(process.stdin as unknown as ReadableStream).text();

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -1,6 +1,6 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { Command } from "commander";
-import { readFileSync } from "fs";
-import { join } from "path";
 import { getCpeCatalogosSchema } from "../cpe/catalogos/index.ts";
 import { outputJSON } from "../utils/output.ts";
 import { packageDataDir } from "../utils/package-data.ts";

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -1,6 +1,6 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { Command } from "commander";
-import { existsSync, readdirSync, readFileSync } from "fs";
-import { join } from "path";
 import { emitNextSteps } from "../utils/next-steps.ts";
 import { output, outputError } from "../utils/output.ts";
 import { packageDataDir } from "../utils/package-data.ts";

--- a/packages/cli/src/commands/tipo-cambio.ts
+++ b/packages/cli/src/commands/tipo-cambio.ts
@@ -20,8 +20,7 @@ export function createTipoCambioCommand(): Command {
 		"Tipo de Cambio oficial SUNAT (USD/PEN) — scrapes the SUNAT portal via agent-browser. T0.",
 	);
 
-	tc
-		.option("--fecha <YYYY-MM-DD>", "Date for which to fetch the rate (defaults to today)")
+	tc.option("--fecha <YYYY-MM-DD>", "Date for which to fetch the rate (defaults to today)")
 		.option("--force", "Bypass local cache (default: cached if present, since SUNAT TC is immutable per date)")
 		.action(async (opts, cmd) => {
 			const format = getFormat(cmd);
@@ -44,8 +43,7 @@ export function createTipoCambioCommand(): Command {
 			}
 		});
 
-	tc
-		.command("cached")
+	tc.command("cached")
 		.description("List rates already cached locally without scraping. T0.")
 		.option("--fecha <YYYY-MM-DD>", "Filter to one specific date")
 		.action((opts, cmd) => {
@@ -56,10 +54,7 @@ export function createTipoCambioCommand(): Command {
 					output(format, { json: r ? { found: true, ...r } : { found: false, fecha: opts.fecha } });
 					return;
 				}
-				outputError(
-					"--fecha required for 'cached' (full cache list shaped, not implemented)",
-					format,
-				);
+				outputError("--fecha required for 'cached' (full cache list shaped, not implemented)", format);
 			} catch (err) {
 				outputError(err instanceof Error ? err.message : String(err), format);
 			}

--- a/packages/cli/src/cpe/drivers/index.ts
+++ b/packages/cli/src/cpe/drivers/index.ts
@@ -1,6 +1,6 @@
-import type { CpeDriver, CpeDriverName } from "./types.ts";
 import { MockDriver } from "./mock.ts";
 import { SunatDirectDriver } from "./sunat-direct.ts";
+import type { CpeDriver, CpeDriverName } from "./types.ts";
 
 export function getDriver(name: CpeDriverName | undefined): CpeDriver {
 	const resolved = name || (process.env.CPE_DRIVER as CpeDriverName | undefined) || "mock";
@@ -21,5 +21,5 @@ export function getDriver(name: CpeDriverName | undefined): CpeDriver {
 	}
 }
 
-export { MockDriver, SunatDirectDriver };
 export * from "./types.ts";
+export { MockDriver, SunatDirectDriver };

--- a/packages/cli/src/cpe/drivers/mock.ts
+++ b/packages/cli/src/cpe/drivers/mock.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from "crypto";
+import { createHash, randomUUID } from "node:crypto";
 import type {
 	BoletaInput,
 	CpeDriver,

--- a/packages/cli/src/cpe/drivers/sunat-direct.ts
+++ b/packages/cli/src/cpe/drivers/sunat-direct.ts
@@ -1,10 +1,17 @@
-import { existsSync } from "fs";
+import { existsSync } from "node:fs";
 import { buildCatalogCoverageReport, hasCatalogWarnings } from "../catalogos/index.ts";
 import { resolveCpeContext } from "../config.ts";
-import { findCachedResult, findStalePendings, idempotencyKey, logFailure, logPending, logSuccess } from "../idempotency.ts";
-import { signFacturaXml } from "../sign/xades.ts";
+import {
+	findCachedResult,
+	findStalePendings,
+	idempotencyKey,
+	logFailure,
+	logPending,
+	logSuccess,
+} from "../idempotency.ts";
 import { loadPfx } from "../sign/cert-loader.ts";
-import { getStatus, pollStatus, sendBill, sendSummary, SUNAT_ENDPOINTS_FAC } from "../soap/client.ts";
+import { signFacturaXml } from "../sign/xades.ts";
+import { getStatus, pollStatus, SUNAT_ENDPOINTS_FAC, sendBill, sendSummary } from "../soap/client.ts";
 import { bajaFilenameRA, buildBajaUbl } from "../ubl/baja.ts";
 import { boletaFilename, boletaRequiresIndividualSubmission, buildBoletaUbl } from "../ubl/boleta.ts";
 import { buildFacturaUbl, facturaFilename } from "../ubl/factura.ts";
@@ -279,9 +286,8 @@ export class SunatDirectDriver implements CpeDriver {
 
 	private async emitNota(input: NotaCreditoInput | NotaDebitoInput, tipo: "07" | "08"): Promise<CpeResult> {
 		const ctx = resolveCpeContext();
-		const errors = tipo === "07"
-			? validateNotaCredito(input as NotaCreditoInput)
-			: validateNotaDebito(input as NotaDebitoInput);
+		const errors =
+			tipo === "07" ? validateNotaCredito(input as NotaCreditoInput) : validateNotaDebito(input as NotaDebitoInput);
 		if (errors.length > 0) {
 			throw new Error(`Validation failed: ${errors.map((e) => `[${e.code}] ${e.message}`).join("; ")}`);
 		}
@@ -290,13 +296,15 @@ export class SunatDirectDriver implements CpeDriver {
 		const cached = findCachedResult(idemKey);
 		if (cached) return cached;
 
-		const unsigned = tipo === "07"
-			? buildNotaCreditoUbl(input as NotaCreditoInput, { emisor: ctx.emisor })
-			: buildNotaDebitoUbl(input as NotaDebitoInput, { emisor: ctx.emisor });
+		const unsigned =
+			tipo === "07"
+				? buildNotaCreditoUbl(input as NotaCreditoInput, { emisor: ctx.emisor })
+				: buildNotaDebitoUbl(input as NotaDebitoInput, { emisor: ctx.emisor });
 		const signed = signFacturaXml(unsigned, { pfxPath: ctx.certPath, pfxPassword: ctx.certPassword });
-		const filename = tipo === "07"
-			? notaCreditoFilename(ctx.emisor.ruc, input.serie, input.numero)
-			: notaDebitoFilename(ctx.emisor.ruc, input.serie, input.numero);
+		const filename =
+			tipo === "07"
+				? notaCreditoFilename(ctx.emisor.ruc, input.serie, input.numero)
+				: notaDebitoFilename(ctx.emisor.ruc, input.serie, input.numero);
 		const hash = `sha256:${await sha256Hex(signed.xml)}`;
 
 		const auditCmd = tipo === "07" ? "cpe nc emit" : "cpe nd emit";
@@ -396,22 +404,17 @@ export class SunatDirectDriver implements CpeDriver {
 				ts: new Date().toISOString(),
 			};
 
-			logSuccess(
-				idemKey,
-				"cpe resumen send",
-				auditArgs,
-				{
-					id: idemId,
-					serie: idemKey.serie,
-					numero: input.correlativo,
-					hash: signed.cert.serialNumber,
-					status: "pending",
-					cdrCode: undefined,
-					cdrDesc: `ticket=${summaryResp.ticket}`,
-					xml: signed.xml,
-					ts: result.ts,
-				} as unknown as never,
-			);
+			logSuccess(idemKey, "cpe resumen send", auditArgs, {
+				id: idemId,
+				serie: idemKey.serie,
+				numero: input.correlativo,
+				hash: signed.cert.serialNumber,
+				status: "pending",
+				cdrCode: undefined,
+				cdrDesc: `ticket=${summaryResp.ticket}`,
+				xml: signed.xml,
+				ts: result.ts,
+			} as unknown as never);
 
 			return result;
 		} catch (err) {
@@ -444,7 +447,10 @@ export class SunatDirectDriver implements CpeDriver {
 		};
 	}
 
-	async pollResumen(ticket: string, opts?: { timeoutMs?: number; onTick?: (n: number, s: string) => void }): Promise<ResumenStatusResult> {
+	async pollResumen(
+		ticket: string,
+		opts?: { timeoutMs?: number; onTick?: (n: number, s: string) => void },
+	): Promise<ResumenStatusResult> {
 		const ctx = resolveCpeContext();
 		const outcome = await pollStatus({
 			mode: ctx.mode,

--- a/packages/cli/src/cpe/oauth-config.ts
+++ b/packages/cli/src/cpe/oauth-config.ts
@@ -6,8 +6,8 @@
  *   Mi RUC y Otros Registros → Apps Móviles → Credenciales API
  */
 
-import type { OAuthCredentials } from "../sunat-rest/oauth.ts";
 import { missingSecretMessage, resolveSecret } from "../data/keychain.ts";
+import type { OAuthCredentials } from "../sunat-rest/oauth.ts";
 
 export function resolveOAuthCredentials(): OAuthCredentials {
 	const clientId = process.env.SUNAT_API_CLIENT_ID;

--- a/packages/cli/src/cpe/sign/cert-loader.ts
+++ b/packages/cli/src/cpe/sign/cert-loader.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync } from "node:fs";
 import forge from "node-forge";
 
 export interface LoadedCert {

--- a/packages/cli/src/cpe/sign/xades.ts
+++ b/packages/cli/src/cpe/sign/xades.ts
@@ -15,7 +15,7 @@
  * 7. Fill in SignatureValue.
  */
 
-import { createSign, createHash } from "crypto";
+import { createHash, createSign } from "node:crypto";
 import { DOMParser, XMLSerializer } from "@xmldom/xmldom";
 import { C14nCanonicalization } from "xml-crypto/lib/c14n-canonicalization.js";
 import { type LoadedCert, loadPfx, pemToBase64Cert } from "./cert-loader.ts";
@@ -113,7 +113,7 @@ function createSignatureSkeleton(doc: Document, signatureId: string, certB64: st
 	return sig;
 }
 
-function computeEnvelopedDigest(doc: Document, signatureEl: Element): string {
+function computeEnvelopedDigest(doc: Document, _signatureEl: Element): string {
 	// Clone the doc, remove the signature, then canonicalize.
 	const clone = new DOMParser().parseFromString(new XMLSerializer().serializeToString(doc), "text/xml");
 	const sigInClone = clone.getElementsByTagNameNS(DS_NS, "Signature")[0];
@@ -130,7 +130,10 @@ function findExtensionContent(doc: Document): Element {
 
 const c14n = new C14nCanonicalization();
 
-function canonicalize(node: Node | Element, ancestorNamespaces: Array<{ prefix: string; namespaceURI: string }> = []): string {
+function canonicalize(
+	node: Node | Element,
+	ancestorNamespaces: Array<{ prefix: string; namespaceURI: string }> = [],
+): string {
 	// biome-ignore lint/suspicious/noExplicitAny: xml-crypto types don't match xmldom types but runtime is compatible
 	return c14n.process(node as any, { ancestorNamespaces }) as string;
 }

--- a/packages/cli/src/cpe/ubl/boleta.ts
+++ b/packages/cli/src/cpe/ubl/boleta.ts
@@ -61,8 +61,7 @@ export function buildBoletaUbl(input: BoletaInput, ctx: BoletaContext): string {
 	const id = `${input.serie}-${input.numero}`;
 	const lines = input.items.map((item, idx) => renderInvoiceLine(item, idx, input.moneda)).join("\n");
 
-	const receptorIn =
-		input.receptor && input.receptor.numDoc ? input.receptor : (defaultReceptor() as BoletaInput["receptor"]);
+	const receptorIn = input.receptor?.numDoc ? input.receptor : (defaultReceptor() as BoletaInput["receptor"]);
 
 	return `<?xml version="1.0" encoding="UTF-8"?>
 <Invoice xmlns="${NS.xmlns}" xmlns:cac="${NS.cac}" xmlns:cbc="${NS.cbc}" xmlns:ds="${NS.ds}" xmlns:ext="${NS.ext}">

--- a/packages/cli/src/cpe/ubl/common.ts
+++ b/packages/cli/src/cpe/ubl/common.ts
@@ -159,7 +159,10 @@ export function renderCacSignature(emisor: EmisorCtx): string {
     </cac:Signature>`;
 }
 
-export function renderTaxAndTotals(totales: { valorVenta: number; igv: number; total: number }, moneda: string): string {
+export function renderTaxAndTotals(
+	totales: { valorVenta: number; igv: number; total: number },
+	moneda: string,
+): string {
 	const totalIgv = round2(totales.igv);
 	const totalValor = round2(totales.valorVenta);
 	const totalPagar = round2(totales.total);

--- a/packages/cli/src/cpe/ubl/gre.ts
+++ b/packages/cli/src/cpe/ubl/gre.ts
@@ -21,13 +21,7 @@
  * Reference: https://github.com/thegreenter/greenter/blob/master/packages/xml/src/Xml/Templates/despatch2022.xml.twig
  */
 
-import {
-	type EmisorCtx,
-	NS,
-	escapeXml,
-	fmt,
-	renderCacSignature,
-} from "./common.ts";
+import { type EmisorCtx, escapeXml, fmt, NS, renderCacSignature } from "./common.ts";
 
 export const GRE_NS = {
 	xmlns: "urn:oasis:names:specification:ubl:schema:xsd:DespatchAdvice-2",

--- a/packages/cli/src/cpe/ubl/nota-credito.ts
+++ b/packages/cli/src/cpe/ubl/nota-credito.ts
@@ -21,9 +21,9 @@ import {
 	escapeXml,
 	renderCacSignature,
 	renderEmisorParty,
+	renderInvoiceLine,
 	renderReceptorParty,
 	renderTaxAndTotals,
-	renderInvoiceLine,
 } from "./common.ts";
 
 export interface NotaContext {

--- a/packages/cli/src/cpe/ubl/nota-debito.ts
+++ b/packages/cli/src/cpe/ubl/nota-debito.ts
@@ -17,11 +17,11 @@ import type { NotaDebitoInput } from "../drivers/types.ts";
 import {
 	type EmisorCtx,
 	escapeXml,
+	fmt,
 	renderCacSignature,
 	renderEmisorParty,
-	renderReceptorParty,
 	renderInvoiceLine,
-	fmt,
+	renderReceptorParty,
 } from "./common.ts";
 
 export interface NotaDebitoContext {

--- a/packages/cli/src/cpe/ubl/resumen.ts
+++ b/packages/cli/src/cpe/ubl/resumen.ts
@@ -71,7 +71,7 @@ function renderSummaryLine(entry: SummaryBoletaEntry, idx: number): string {
 	// SUNAT element order (per Greenter twig + SUNAT XSD):
 	// LineID, DocumentTypeCode, ID, AccountingCustomerParty, [BillingReference],
 	// cac:Status, sac:TotalAmount, sac:BillingPayment*, cac:TaxTotal+
-	const receptorBlock = entry.receptor && entry.receptor.numDoc
+	const receptorBlock = entry.receptor?.numDoc
 		? `            <cac:AccountingCustomerParty>
                 <cbc:CustomerAssignedAccountID>${escapeXml(entry.receptor.numDoc)}</cbc:CustomerAssignedAccountID>
                 <cbc:AdditionalAccountID>${escapeXml(entry.receptor.tipoDoc)}</cbc:AdditionalAccountID>

--- a/packages/cli/src/cpe/validation/reglas.ts
+++ b/packages/cli/src/cpe/validation/reglas.ts
@@ -5,7 +5,14 @@
  * before hitting the SUNAT SOAP endpoint. Full SUNAT catalog is ~600 rules.
  */
 
-import type { BoletaInput, CpeItem, CpeTotales, FacturaInput, NotaCreditoInput, NotaDebitoInput } from "../drivers/types.ts";
+import type {
+	BoletaInput,
+	CpeItem,
+	CpeTotales,
+	FacturaInput,
+	NotaCreditoInput,
+	NotaDebitoInput,
+} from "../drivers/types.ts";
 import { BOLETA_RECEPTOR_REQUIRED_THRESHOLD } from "../ubl/boleta.ts";
 
 export interface ValidationError {
@@ -249,7 +256,11 @@ export function validateBoleta(input: BoletaInput, today = new Date()): Validati
 			}
 		}
 		if (!r.rznSocial || r.rznSocial.length === 0) {
-			errors.push({ code: "RZN_SOCIAL", field: "receptor.rznSocial", message: "rznSocial required when receptor present" });
+			errors.push({
+				code: "RZN_SOCIAL",
+				field: "receptor.rznSocial",
+				message: "rznSocial required when receptor present",
+			});
 		}
 	}
 

--- a/packages/cli/src/schemas/cpe-nota-credito.json
+++ b/packages/cli/src/schemas/cpe-nota-credito.json
@@ -28,6 +28,9 @@
 		"--driver <name>": "Override active driver"
 	},
 	"trust": "T2",
-	"safety": ["Plazo igual que el documento referenciado.", "Para anulaciones totales prefer 'cpe factura void' (T3 con intent token)."],
+	"safety": [
+		"Plazo igual que el documento referenciado.",
+		"Para anulaciones totales prefer 'cpe factura void' (T3 con intent token)."
+	],
 	"status": "STUB — driver=mock works."
 }

--- a/packages/cli/src/schemas/rhe.json
+++ b/packages/cli/src/schemas/rhe.json
@@ -35,7 +35,16 @@
 		},
 		"medioPago": {
 			"type": "enum",
-			"values": ["DEPOSITO", "GIRO", "TRANSFERENCIA", "ORDEN DE PAGO", "TARJETA DEBITO", "TARJETA CREDITO", "CHEQUE", "EFECTIVO"],
+			"values": [
+				"DEPOSITO",
+				"GIRO",
+				"TRANSFERENCIA",
+				"ORDEN DE PAGO",
+				"TARJETA DEBITO",
+				"TARJETA CREDITO",
+				"CHEQUE",
+				"EFECTIVO"
+			],
 			"default": "TRANSFERENCIA",
 			"description": "Payment method used."
 		},

--- a/packages/cli/src/sunat-rest/consulta-cpe.ts
+++ b/packages/cli/src/sunat-rest/consulta-cpe.ts
@@ -11,7 +11,7 @@
  * Note: requires OAuth client_credentials with scope 'contribuyente'.
  */
 
-import { type OAuthCredentials, callRestApi } from "./oauth.ts";
+import { callRestApi, type OAuthCredentials } from "./oauth.ts";
 
 export type CpeTipoCode = "01" | "03" | "07" | "08" | "20" | "40" | "R1" | "R7" | "09";
 

--- a/packages/cli/src/sunat-rest/gre.ts
+++ b/packages/cli/src/sunat-rest/gre.ts
@@ -10,9 +10,9 @@
  * Async pattern same as SIRE: send → ticket → poll status → CDR ZIP
  */
 
-import { createHash } from "crypto";
-import { type OAuthCredentials, callRestApi, getAccessToken } from "./oauth.ts";
+import { createHash } from "node:crypto";
 import { zipSingleFile } from "../cpe/soap/zip.ts";
+import { callRestApi, type OAuthCredentials } from "./oauth.ts";
 
 /**
  * Build SIRE-style credentials for GRE (same shape, different scope).
@@ -122,16 +122,30 @@ export async function pollGreTicket(opts: GrePollOpts): Promise<GrePollResult> {
 		const status = await consultarGreTicket(opts.numTicket, opts.creds);
 		opts.onTick?.(attempt, status.codRespuesta);
 		if (status.codRespuesta === "0001") {
-			return { state: "completed", codRespuesta: status.codRespuesta, desRespuesta: status.desRespuesta, arcCdr: status.arcCdr };
+			return {
+				state: "completed",
+				codRespuesta: status.codRespuesta,
+				desRespuesta: status.desRespuesta,
+				arcCdr: status.arcCdr,
+			};
 		}
 		if (status.codRespuesta === "0002" || status.codRespuesta === "0003") {
-			return { state: "rejected", codRespuesta: status.codRespuesta, desRespuesta: status.desRespuesta, arcCdr: status.arcCdr };
+			return {
+				state: "rejected",
+				codRespuesta: status.codRespuesta,
+				desRespuesta: status.desRespuesta,
+				arcCdr: status.arcCdr,
+			};
 		}
 		// 0098 / unknown → still processing
 		await sleep(delay);
 		delay = Math.min(delay * 2, maxDelay);
 	}
-	return { state: "still-processing", codRespuesta: "0098", desRespuesta: `Timeout after ${Math.round((Date.now() - start) / 1000)}s` };
+	return {
+		state: "still-processing",
+		codRespuesta: "0098",
+		desRespuesta: `Timeout after ${Math.round((Date.now() - start) / 1000)}s`,
+	};
 }
 
 function sleep(ms: number): Promise<void> {

--- a/packages/cli/src/sunat-rest/padron-local.ts
+++ b/packages/cli/src/sunat-rest/padron-local.ts
@@ -17,11 +17,19 @@
  * index is shaped for a follow-up PR.
  */
 
-import { createHash } from "crypto";
-import { createReadStream, createWriteStream, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs";
-import { join } from "path";
-import { paths } from "../data/config.ts";
+import { createHash } from "node:crypto";
+import {
+	createReadStream,
+	createWriteStream,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
 import yauzl from "yauzl";
+import { paths } from "../data/config.ts";
 
 const PADRON_URL = "http://www2.sunat.gob.pe/padron_reducido_ruc.zip";
 const CACHE_DIR = join(paths.sunatDir, "cache");

--- a/packages/cli/src/sunat-rest/ruc-portal.ts
+++ b/packages/cli/src/sunat-rest/ruc-portal.ts
@@ -66,7 +66,10 @@ export function parseRucSnapshot(snapshot: string, ruc: string): RucPortalEntry 
 		// where the last segment before " - X - Y" is the address tail with the
 		// distrito appended. We pull the last 3 hyphen-segments and then
 		// tokenize the leftmost of those to extract the distrito.
-		const parts = direccion.split(/\s*-\s*/).map((p) => p.trim()).filter(Boolean);
+		const parts = direccion
+			.split(/\s*-\s*/)
+			.map((p) => p.trim())
+			.filter(Boolean);
 		if (parts.length >= 3) {
 			departamento = parts[parts.length - 1];
 			provincia = parts[parts.length - 2];

--- a/packages/cli/src/sunat-rest/tipo-cambio.ts
+++ b/packages/cli/src/sunat-rest/tipo-cambio.ts
@@ -22,8 +22,8 @@
  * the legally valid TC for that date.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { paths } from "../data/config.ts";
 
 export interface TipoCambioRate {
@@ -140,7 +140,9 @@ async function fetchMonth(anio: number, mesIndex: number): Promise<TcRow[]> {
 		body: JSON.stringify({ anio, mes: mesIndex, token: "x" }),
 	});
 	if (!res.ok) {
-		throw new Error(`SUNAT TC endpoint returned HTTP ${res.status} for ${anio}-${String(mesIndex + 1).padStart(2, "0")}`);
+		throw new Error(
+			`SUNAT TC endpoint returned HTTP ${res.status} for ${anio}-${String(mesIndex + 1).padStart(2, "0")}`,
+		);
 	}
 	const text = await res.text();
 	if (text.includes("Request Rejected")) {

--- a/packages/cli/src/validation/input.ts
+++ b/packages/cli/src/validation/input.ts
@@ -70,7 +70,14 @@ export function sanitizePath(path: string): string {
 	return cleaned;
 }
 
-const VALID_TIPO_DOC = ["SIN DOCUMENTO", "RUC", "DNI", "CARNET DE EXTRANJERIA", "PASAPORTE", "CED. DIPLOMATICA DE IDENTIDAD"] as const;
+const VALID_TIPO_DOC = [
+	"SIN DOCUMENTO",
+	"RUC",
+	"DNI",
+	"CARNET DE EXTRANJERIA",
+	"PASAPORTE",
+	"CED. DIPLOMATICA DE IDENTIDAD",
+] as const;
 export type TipoDocumento = (typeof VALID_TIPO_DOC)[number];
 
 export function validateTipoDoc(tipo: string): TipoDocumento {
@@ -82,7 +89,7 @@ export function validateTipoDoc(tipo: string): TipoDocumento {
 	return found;
 }
 
-const VALID_MONEDA = ["PEN", "USD", "SOL", "DOLAR DE NORTE AMERICA"] as const;
+const _VALID_MONEDA = ["PEN", "USD", "SOL", "DOLAR DE NORTE AMERICA"] as const;
 export function validateMoneda(moneda: string): "PEN" | "USD" {
 	const upper = moneda.trim().toUpperCase();
 	if (upper === "PEN" || upper === "SOL") return "PEN";

--- a/packages/cli/src/workflows/f616-constancias.ts
+++ b/packages/cli/src/workflows/f616-constancias.ts
@@ -23,7 +23,7 @@ export interface ResultadoConstancias {
 export async function descargarConstancias(dir: string): Promise<ResultadoConstancias> {
 	const s = await connect({ probe: PROBE });
 	try {
-		let descargas = 0;
+		let _descargas = 0;
 		// El evento llega por el canal crudo, no por evalIn.
 		await s.send("Browser.setDownloadBehavior", { behavior: "allowAndName", downloadPath: dir, eventsEnabled: true });
 		await new Promise((r) => setTimeout(r, 800));
@@ -31,10 +31,11 @@ export async function descargarConstancias(dir: string): Promise<ResultadoConsta
 		const clicked = await s.evalIn(
 			`(function(){var b=[...document.querySelectorAll('button,a')].find(function(e){return e.offsetParent!==null&&/^\\s*Guardar\\s*$/i.test(e.innerText||'')});if(b){b.click();return 1}return 0})()`,
 		);
-		if (!clicked.val) return { ok: false, dir, mensaje: "No encontré el botón Guardar. ¿Está abierto el visor de constancias?" };
+		if (!clicked.val)
+			return { ok: false, dir, mensaje: "No encontré el botón Guardar. ¿Está abierto el visor de constancias?" };
 
 		await new Promise((r) => setTimeout(r, 4000));
-		descargas++;
+		_descargas++;
 		return { ok: true, dir, mensaje: "El PDF trae todas las constancias del lote." };
 	} finally {
 		s.close();

--- a/packages/cli/src/workflows/f616-declare.ts
+++ b/packages/cli/src/workflows/f616-declare.ts
@@ -10,7 +10,7 @@
  * Medido contra el portal el 2026-08-22/23. Ver `recon/sunat-f616-api.md`.
  */
 
-import { connect, NATIVE_SETTER, type CdpSession } from "../browser/cdp.ts";
+import { type CdpSession, connect, NATIVE_SETTER } from "../browser/cdp.ts";
 
 /** El visor puede tener varios contextos vivos; este los distingue. */
 const PROBE = `!!document.getElementById('casilla007')||!!document.getElementById('mytable')`;
@@ -42,18 +42,26 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 /** Cierra bootbox/modales abiertos: si queda uno, se come el próximo clic. */
 async function limpiarDialogos(s: CdpSession): Promise<void> {
 	for (let i = 0; i < 4; i++) {
-		const n = await s.evalIn(`[...document.querySelectorAll('.bootbox,.modal')].filter(function(m){return m.offsetParent!==null}).length`);
+		const n = await s.evalIn(
+			`[...document.querySelectorAll('.bootbox,.modal')].filter(function(m){return m.offsetParent!==null}).length`,
+		);
 		if (!Number(n.val)) return;
 		// Sin tocar "Otro formulario": ese botón resetea el formulario entero.
-		await s.evalIn(`(function(){var b=[...document.querySelectorAll('.bootbox button,.modal button')].find(function(x){return x.offsetParent!==null&&/^(Aceptar|OK|Cancelar)$/i.test(x.innerText.trim())});if(b)b.click();})()`);
+		await s.evalIn(
+			`(function(){var b=[...document.querySelectorAll('.bootbox button,.modal button')].find(function(x){return x.offsetParent!==null&&/^(Aceptar|OK|Cancelar)$/i.test(x.innerText.trim())});if(b)b.click();})()`,
+		);
 		await sleep(1200);
 	}
 }
 
 /** Acepta el bootbox visible y devuelve su texto. */
 async function aceptarDialogo(s: CdpSession): Promise<string> {
-	const txt = await s.evalIn(`[...document.querySelectorAll('.bootbox')].map(function(b){return b.innerText.replace(/\\s+/g,' ').trim()}).join(' | ')`);
-	await s.evalIn(`(function(){var b=[...document.querySelectorAll('.bootbox button')].find(function(x){return /^(Aceptar|S[ií])$/i.test(x.innerText.trim())});if(b)b.click();})()`);
+	const txt = await s.evalIn(
+		`[...document.querySelectorAll('.bootbox')].map(function(b){return b.innerText.replace(/\\s+/g,' ').trim()}).join(' | ')`,
+	);
+	await s.evalIn(
+		`(function(){var b=[...document.querySelectorAll('.bootbox button')].find(function(x){return /^(Aceptar|S[ií])$/i.test(x.innerText.trim())});if(b)b.click();})()`,
+	);
 	return String(txt.val || "").slice(0, 160);
 }
 
@@ -72,7 +80,12 @@ export async function conectarF616(): Promise<CdpSession> {
  * `casilla007` actualiza el valor pero NO reconstruye las reglas de
  * validación del modal de ingresos, que quedan atadas al periodo anterior.
  */
-export async function abrirPeriodo(s: CdpSession, mmyyyy: string, telefono: string, profesion = "INGENIERO"): Promise<boolean> {
+export async function abrirPeriodo(
+	s: CdpSession,
+	mmyyyy: string,
+	telefono: string,
+	profesion = "INGENIERO",
+): Promise<boolean> {
 	await limpiarDialogos(s);
 	await s.evalIn(`(function(){var set=${NATIVE_SETTER};return set('casilla007',${JSON.stringify(mmyyyy)});})()`);
 	await sleep(3500);
@@ -87,7 +100,9 @@ if(o){Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype,'value'
 return 'ok';})()`);
 	await sleep(1200);
 
-	const disabled = await s.evalIn(`document.getElementById('btnSigiente')?document.getElementById('btnSigiente').disabled:true`);
+	const disabled = await s.evalIn(
+		`document.getElementById('btnSigiente')?document.getElementById('btnSigiente').disabled:true`,
+	);
 	return !disabled.val;
 }
 
@@ -103,7 +118,10 @@ export async function periodoAbierto(s: CdpSession): Promise<string> {
  * El orden importa: el radio de tipo de documento limpia los campos de
  * identidad, así que va antes de llenarlos.
  */
-export async function agregarIngreso(s: CdpSession, ing: IngresoF616): Promise<{ ok: boolean; error?: string; filas?: number }> {
+export async function agregarIngreso(
+	s: CdpSession,
+	ing: IngresoF616,
+): Promise<{ ok: boolean; error?: string; filas?: number }> {
 	await limpiarDialogos(s);
 	await s.evalIn(`document.getElementById('nuevo').click()`);
 	await sleep(2500);
@@ -112,9 +130,13 @@ export async function agregarIngreso(s: CdpSession, ing: IngresoF616): Promise<{
 	await sleep(1200);
 
 	const campos: Array<[string, string]> = [
-		["nomPaterno", ing.apePat], ["nomMaterno", ing.apeMat], ["textNombres", ing.nombres],
-		["textSerie", ing.serie], ["textNumero", ing.numero],
-		["textFecEmision", ing.fecha], ["textFecPago", ing.fecha],
+		["nomPaterno", ing.apePat],
+		["nomMaterno", ing.apeMat],
+		["textNombres", ing.nombres],
+		["textSerie", ing.serie],
+		["textNumero", ing.numero],
+		["textFecEmision", ing.fecha],
+		["textFecPago", ing.fecha],
 		["textMonto", String(ing.monto)],
 	];
 	const r = await s.evalIn(`(function(){var set=${NATIVE_SETTER};var o=[];
@@ -126,7 +148,9 @@ return o.join(' | ');})()`);
 	await s.evalIn(`document.getElementById('btnGrabar').click()`);
 	await sleep(2000);
 
-	const errs = await s.evalIn(`[...document.querySelectorAll('.modal [id$=Error]')].map(function(e){return e.innerText.trim()}).filter(Boolean).join(' ;; ')`);
+	const errs = await s.evalIn(
+		`[...document.querySelectorAll('.modal [id$=Error]')].map(function(e){return e.innerText.trim()}).filter(Boolean).join(' ;; ')`,
+	);
 	if (errs.val) return { ok: false, error: String(errs.val) };
 
 	await aceptarDialogo(s);
@@ -151,12 +175,15 @@ return o.join(' | ');})()`);
 export async function leerDeuda(s: CdpSession): Promise<DeudaF616> {
 	const yaEsta = await s.evalIn(`document.getElementById('casilla355')?document.getElementById('casilla355').value:''`);
 	if (!yaEsta.val) {
-		await s.evalIn(`(function(){var a=[...document.querySelectorAll('a.nav-link')].find(function(x){return /Detalle de Ingr/i.test(x.innerText||'')});if(a)a.click();})()`);
+		await s.evalIn(
+			`(function(){var a=[...document.querySelectorAll('a.nav-link')].find(function(x){return /Detalle de Ingr/i.test(x.innerText||'')});if(a)a.click();})()`,
+		);
 		await sleep(1800);
 		await s.evalIn(`(function(){var b=document.getElementById('btnSigiente');if(b&&!b.disabled)b.click();})()`);
 		await sleep(2500);
 	}
-	const get = async (id: string) => String((await s.evalIn(`document.getElementById('${id}')?document.getElementById('${id}').value:''`)).val || "");
+	const get = async (id: string) =>
+		String((await s.evalIn(`document.getElementById('${id}')?document.getElementById('${id}').value:''`)).val || "");
 	return {
 		baseImponible: await get("casilla307"),
 		impuesto: await get("casilla343"),
@@ -197,6 +224,8 @@ export async function limpiarIngresos(s: CdpSession): Promise<number> {
 
 /** Las filas cargadas, como texto. */
 export async function listarIngresos(s: CdpSession): Promise<string[]> {
-	const r = await s.evalIn(`[...document.querySelectorAll('#mytable tbody tr')].map(function(tr){return [...tr.querySelectorAll('td')].map(function(td){return td.innerText.trim()}).slice(0,10).join(' | ')})`);
+	const r = await s.evalIn(
+		`[...document.querySelectorAll('#mytable tbody tr')].map(function(tr){return [...tr.querySelectorAll('td')].map(function(td){return td.innerText.trim()}).slice(0,10).join(' | ')})`,
+	);
 	return (r.val as string[]) || [];
 }

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -12,7 +12,7 @@
 		"shiki": "^4.0.2"
 	},
 	"devDependencies": {
-		"sharp": "0.35.0",
+		"sharp": "0.35.3",
 		"vite": "8.2.2"
 	}
 }


### PR DESCRIPTION
Closes #53, #54, #55, #56, #57, #58, #59.

No security advisory is open on this repo (`dependabot/alerts` returns nothing), so these are maintenance. Each was exercised rather than merged on a green badge.

## commander 14 to 15, the one that mattered

Commander's action-argument arity is exactly what made `cpe driver list` crash with `TypeError: parent.opts is not a function`, so a major bump there is the riskiest item in the set. The arity-sensitive paths were run by hand:

| path | result |
|---|---|
| `cpe driver list` (2 registered arguments) | answers, no crash |
| `cpe void prepare` (1 argument, correct by accident before) | answers |
| `cpe guia --help` (native alias) | prints its help |
| `rhe emit --help` (`--params`) | flag intact |

Also verified in the built artifact under plain `node` with bun off PATH, since that is what ships now.

## actions/checkout to v7 needed a companion change

v5 onward changed the `persist-credentials` default, and the tag step pushes with git, so it needs credentials. The value is now stated explicitly instead of inherited. Leaving it implicit means a future bump breaks the release after the package is already on npm, which is the exact failure this repo hit on 0.9.0 and 0.10.0.

## biome 2.5.10 surfaced 20 pre-existing findings

All the same rule: imports missing the `node:` protocol. Fixed, because the published artifact now runs on Node and the prefix is what makes resolution unambiguous there.

The five that remain are explicit `any` in the CDP client. That is typing an external protocol, not lint, and it is out of scope here.

## Lockfiles

`package-lock.json` regenerated alongside `bun.lock`. The release runs `npm ci`, so a lockfile left behind would have installed the old versions in CI while local runs used the new ones. `npm ci` verified clean.

## Tests

458 pass, 0 fail, unchanged.