### PR TITLE
docs(skill,site): describe the CLI as it behaves now

### DIFF
--- a/packages/cli/src/skills/core.md
+++ b/packages/cli/src/skills/core.md
@@ -2,7 +2,9 @@
 
 SUNAT tax automation via `npx @crafter/sunat-cli` (or `sunat-cli` if globally installed).
 
-Install: `npm install -g @crafter/sunat-cli`
+Install: `npm install -g @crafter/sunat-cli`. Runs on Node, no Bun needed.
+
+RHE and F616 additionally need [agent-browser](https://github.com/vercel-labs/agent-browser) and Chrome; CPE, SIRE and GRE need a SUNAT certificate and a clave SOL. Everything else works with neither.
 
 Current beta posture: supervised RHE/F616 beta, not autonomous filing. Real SUNAT operations require `--yes --live-sunat`, should use `--preview-only` first, and must stop if preview values cannot be parsed or reconciled.
 
@@ -125,8 +127,25 @@ Use `sunat-cli schema <resource>` to get machine-readable field definitions befo
 ## Output Formats
 
 All commands support `--output <format>`:
-- `auto` (default): human-readable
-- `json`: machine-readable, pipe to `jq`
+- `auto` (default): JSON when stdout is not a terminal, a human view when it is
+- `json`: JSON always
+- `table`: the human view always, even under a pipe
+
+**You do not need to pass anything.** Capturing stdout makes it non-interactive,
+so `auto` already gives you JSON. `-o json` only matters when you want JSON while
+attached to a terminal.
+
+Data goes to stdout, diagnostics to stderr. A failing command leaves stdout empty
+and reports on stderr, so `cmd > out.json` never mixes an error into the file you
+are about to parse.
+
+Some commands emit next-step hints on **stderr**, one NDJSON object per line,
+shaped `{"type":"next-step","command":"...","description":"..."}`. They tell you
+what to run next without re-planning. Ignore stderr and stdout is unchanged.
+
+Two exceptions, both deliberate: `skills get <name>` serves raw markdown rather
+than JSON, because a document escaped inside a JSON string is unreadable, and
+`--params` takes JSON *in* rather than controlling output.
 
 ## Common Workflows
 

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -141,27 +141,27 @@ const roadmap = [
 
 const featureHtmls = await Promise.all(features.map((f) => codeToHtml(f.code, { lang: "bash", theme: sunatTheme })));
 
-const heroCode = `# Install globally
+const heroCode = `# Install globally. Runs on Node, no Bun needed
 $ npm install -g @crafter/sunat-cli
 
-# Introspect schema (agents self-serve)
-$ sunat-cli schema cpe-factura --output json
-{ "command": "cpe factura emit", "fields": {...} }
+# Introspect the schema, versioned so agents can pin it
+$ sunat-cli schema cpe-factura
+{ "version": "1.0.0", "command": "cpe factura emit", "fields": {...} }
 
-# Always dry-run first
-$ sunat-cli cpe factura preview --params @factura.json
+# Always preview first
+$ sunat-cli cpe factura preview --params "$(cat factura.json)"
 { "dryRun": true, "hash": "sha256:...", "validacion": {"ok": true} }
 
-# Ship it — UBL 2.1 + XAdES + SOAP, end-to-end
-$ sunat-cli cpe factura emit --params @factura.json --yes
+# Ship it. UBL 2.1 + XAdES + SOAP, end to end
+$ sunat-cli cpe factura emit --params "$(cat factura.json)" --yes
 ✓ Aceptado · CDR 0000 · F001-1234`;
 
 const heroCodeHtml = await codeToHtml(heroCode, { lang: "bash", theme: sunatTheme });
 
 const principles = [
-	"--json payloads over flags",
+	"--params payloads over flags",
 	"--dry-run for all mutations",
-	"--output json by default",
+	"JSON when stdout is not a terminal",
 	"Schema introspection at runtime",
 	"Input hardening against hallucinations",
 	"SKILL.md per agentskills.io spec",


### PR DESCRIPTION
The agent manual and the site both described an older CLI. Each claim below was run against the binary rather than reasoned about.

## The output contract was stated backwards

The manual said `auto` meant human-readable. It does not, and this is the single most useful thing an agent can know about this CLI:

```
auto (default): JSON when stdout is not a terminal, a human view when it is
```

Stating the opposite pushed callers toward `-o json`, a flag they never needed, and left them unsure what a captured run would return.

The section now also covers what was never written down: data on stdout and diagnostics on stderr, a failing command leaving stdout empty, next-step hints arriving on stderr as NDJSON, and the two deliberate exceptions (`skills get` serves raw markdown, `--params` takes JSON in).

Verified, in order: `auto` under a pipe parses as JSON; `-o table` under a pipe does not; `f616 declare` with no arguments writes zero bytes to stdout; `whoami` emits a `next-step` object on stderr; `skills get core` starts with `#`.

## The site showed a flag form that does not work

The hero ran `--params @factura.json`. The flag takes a JSON string, not an `@file` path, so anyone copying it got an error. Replaced with `--params "$(cat factura.json)"`, which runs.

Its principles list led with "--json payloads over flags", which is the convention this project retired in 0.10.0. Now "--params payloads over flags" and "JSON when stdout is not a terminal".

The schema sample gained the `version` field it actually returns.

## Both now say installing needs no Bun

Which became true in 0.10.0 and was the reason for that release.

458 pass, 0 fail. Website builds.