### PR TITLE
chore(release): 0.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3774,7 +3774,7 @@
 		},
 		"packages/cli": {
 			"name": "@crafter/sunat-cli",
-			"version": "0.10.0",
+			"version": "0.10.1",
 			"license": "MIT",
 			"dependencies": {
 				"@clack/prompts": "^1.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/sunat-cli",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"description": "Agent-first CLI for SUNAT tax automation",
 	"module": "bin/sunat.ts",
 	"type": "module",


### PR DESCRIPTION
Four merged changes are sitting unreleased, one of which changes behavior an agent depends on.

## Fixes

`skills list` served its human table under a pipe, and its summaries were truncated at 78 characters inside the machine contract, so an agent received the abbreviation built for a terminal column instead of the description.

The release pipeline now retries the install verification and tags even when a later check fails. Publish runs before every verification step, so a failure there left the package on npm with no tag and no release. That happened on 0.9.0 and again on 0.10.0, and both needed finishing by hand.

## Chores

Every open Dependabot bump, each exercised rather than merged on a green badge. commander 15 in particular had its arity-sensitive paths run by hand, since that API is what made `cpe driver list` crash.

Imports now carry the `node:` protocol, which the published Node artifact resolves unambiguously.

The agent manual and the site described an older CLI: the manual said `auto` meant human-readable when it emits JSON under a pipe, and the site showed `--params @factura.json`, a form the flag does not accept.

## Verification

458 pass, 0 fail. Website builds. This is the first release to run through the repaired tag step, so it also tests that fix.