### PR TITLE
feat: make agent-browser a declared dependency instead of a PATH assumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,19 @@ sunat-cli --help
 
 That help output is the contract. Every command it prints exists in the version you have.
 
-Requires [Bun](https://bun.sh) 1.2+. RHE and F616 also need [agent-browser](https://github.com/vercel-labs/agent-browser) 0.22+ and Chrome. CPE, SIRE and GRE need a SUNAT digital certificate (PFX) and a clave SOL.
+Runs on Node, no Bun needed.
+
+RHE, F616 and the portal scrapers drive a real browser through [agent-browser](https://github.com/vercel-labs/agent-browser), a separate binary:
+
+```bash
+npm install -g agent-browser      # all platforms
+brew install agent-browser        # macOS
+agent-browser install             # download Chrome, first time only
+```
+
+CPE, SIRE and GRE need a SUNAT digital certificate (PFX) and a clave SOL instead. Everything else works with neither.
+
+Run `sunat-cli doctor` to see what is present and what each gap needs.
 
 ## Quick start
 
@@ -38,11 +50,12 @@ Output is JSON whenever stdout is not a terminal, so an agent gets parseable dat
 
 ## Commands
 
-Fourteen namespaces. Run `sunat-cli <name> --help` for any of them.
+Fifteen namespaces. Run `sunat-cli <name> --help` for any of them.
 
 | Namespace | What it does |
 |---|---|
 | `login`, `whoami`, `keychain` | authenticate and inspect the session |
+| `doctor` | what is installed, what is missing, and the command that fixes it |
 | `schema` | field specs per command, for agents |
 | `skills` | the agent manual, served by the binary |
 | `rhe`, `f616` | recibos por honorarios and the monthly declaration (personas naturales) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -3798,6 +3798,14 @@
 			},
 			"engines": {
 				"node": ">=24"
+			},
+			"peerDependencies": {
+				"agent-browser": ">=0.22"
+			},
+			"peerDependenciesMeta": {
+				"agent-browser": {
+					"optional": true
+				}
 			}
 		},
 		"packages/cli/node_modules/commander": {

--- a/packages/cli/bin/sunat.ts
+++ b/packages/cli/bin/sunat.ts
@@ -10,6 +10,7 @@ import { createLoginCommand } from "../src/commands/login.ts";
 import { createPadronCommand } from "../src/commands/padron/index.ts";
 import { createRentaCommand } from "../src/commands/renta/index.ts";
 import { createRheCommand } from "../src/commands/rhe/index.ts";
+import { createDoctorCommand } from "../src/commands/doctor.ts";
 import { createSchemaCommand } from "../src/commands/schema.ts";
 import { createSireCommand } from "../src/commands/sire/index.ts";
 import { createSkillsCommand } from "../src/commands/skills.ts";
@@ -46,6 +47,7 @@ program
 program.addCommand(createLoginCommand());
 program.addCommand(createWhoamiCommand());
 program.addCommand(createSchemaCommand());
+program.addCommand(createDoctorCommand());
 program.addCommand(createRheCommand());
 program.addCommand(createF616Command());
 program.addCommand(createSkillsCommand());

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -67,5 +67,13 @@
 		"@types/node-forge": "^1.3.14",
 		"@types/yauzl": "^3.4.0",
 		"@types/yazl": "^3.3.1"
+	},
+	"peerDependencies": {
+		"agent-browser": ">=0.22"
+	},
+	"peerDependenciesMeta": {
+		"agent-browser": {
+			"optional": true
+		}
 	}
 }

--- a/packages/cli/src/browser/client.ts
+++ b/packages/cli/src/browser/client.ts
@@ -2,6 +2,7 @@ import { execSync, spawn } from "node:child_process";
 import { rmSync } from "node:fs";
 import { privateChildEnv } from "../data/child-process.ts";
 import { secureExistingFile } from "../data/private-storage.ts";
+import { isMissingBinary, missingBinaryError } from "./dependency.ts";
 
 export interface BrowserResult {
 	stdout: string;
@@ -23,7 +24,7 @@ async function run(args: string[], timeoutMs = 30000): Promise<BrowserResult> {
 		proc.stdout.on("data", (d: Buffer) => (stdout += d.toString()));
 		proc.stderr.on("data", (d: Buffer) => (stderr += d.toString()));
 		proc.on("close", (code) => resolve({ stdout: stdout.trim(), stderr: stderr.trim(), exitCode: code || 0 }));
-		proc.on("error", reject);
+		proc.on("error", (err) => reject(isMissingBinary(err) ? missingBinaryError() : err));
 	});
 }
 
@@ -38,7 +39,7 @@ async function runRaw(args: string[], timeoutMs = 30000): Promise<BrowserResult>
 		proc.stdout.on("data", (d: Buffer) => (stdout += d.toString()));
 		proc.stderr.on("data", (d: Buffer) => (stderr += d.toString()));
 		proc.on("close", (code) => resolve({ stdout: stdout.trim(), stderr: stderr.trim(), exitCode: code || 0 }));
-		proc.on("error", reject);
+		proc.on("error", (err) => reject(isMissingBinary(err) ? missingBinaryError() : err));
 	});
 }
 
@@ -53,7 +54,7 @@ async function runBatchFromStdin(command: string[], timeoutMs = 30000): Promise<
 		proc.stdout.on("data", (d: Buffer) => (stdout += d.toString()));
 		proc.stderr.on("data", (d: Buffer) => (stderr += d.toString()));
 		proc.on("close", (code) => resolve({ stdout: stdout.trim(), stderr: stderr.trim(), exitCode: code || 0 }));
-		proc.on("error", reject);
+		proc.on("error", (err) => reject(isMissingBinary(err) ? missingBinaryError() : err));
 		proc.stdin.end(JSON.stringify([command]));
 	});
 }
@@ -128,7 +129,7 @@ export async function evalJS(code: string): Promise<string> {
 			if (exitCode !== 0) reject(new Error("Browser evaluation failed"));
 			else resolve(stripAnsi(stdout.trim()));
 		});
-		proc.on("error", reject);
+		proc.on("error", (err) => reject(isMissingBinary(err) ? missingBinaryError() : err));
 		proc.stdin.write(code);
 		proc.stdin.end();
 	});

--- a/packages/cli/src/browser/dependency.ts
+++ b/packages/cli/src/browser/dependency.ts
@@ -1,0 +1,55 @@
+import { execFileSync } from "node:child_process";
+
+export const AGENT_BROWSER_INSTALL = [
+	"npm install -g agent-browser      # all platforms",
+	"brew install agent-browser        # macOS",
+	"agent-browser install             # download Chrome, first time only",
+].join("\n");
+
+/**
+ * `agent-browser` is spawned by name, so it is a PATH dependency that npm
+ * cannot see. When it is absent the spawn fails with ENOENT and the caller
+ * reports whatever it was doing, which reads as a broken CLI rather than a
+ * missing tool.
+ *
+ * This turns that into an error that names the cause and the fix, in the same
+ * shape as the shebang problem the Node build removed.
+ */
+export function isMissingBinary(err: unknown): boolean {
+	return (err as NodeJS.ErrnoException)?.code === "ENOENT";
+}
+
+export function missingBinaryError(): Error {
+	const e = new Error(
+		`agent-browser is not installed. RHE, F616 and the portal scrapers drive a real browser through it.\n\n${AGENT_BROWSER_INSTALL.split(
+			"\n",
+		)
+			.map((l) => `  ${l}`)
+			.join("\n")}\n\nOr run it once without installing: npx agent-browser open example.com`,
+	);
+	(e as NodeJS.ErrnoException).code = "AGENT_BROWSER_MISSING";
+	return e;
+}
+
+export type BinaryStatus = {
+	installed: boolean;
+	version?: string;
+	hint?: string;
+};
+
+/** Cheap presence probe for `doctor`. Never throws. */
+export function probeAgentBrowser(): BinaryStatus {
+	try {
+		const out = execFileSync("agent-browser", ["--version"], {
+			encoding: "utf-8",
+			timeout: 10000,
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+		return { installed: true, version: out.trim() };
+	} catch (err) {
+		if (isMissingBinary(err)) {
+			return { installed: false, hint: AGENT_BROWSER_INSTALL };
+		}
+		return { installed: false, hint: `agent-browser is on PATH but did not answer --version: ${String(err)}` };
+	}
+}

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,86 @@
+import { existsSync } from "node:fs";
+import { Command } from "commander";
+import { probeAgentBrowser } from "../browser/dependency.ts";
+import { paths } from "../data/config.ts";
+import { isHumanFormat, output } from "../utils/output.ts";
+import { danger, dim, muted, ok, warn } from "../utils/style.ts";
+
+type Check = {
+	name: string;
+	ok: boolean;
+	required: boolean;
+	detail: string;
+	hint?: string;
+};
+
+function checks(): Check[] {
+	const ab = probeAgentBrowser();
+	const configured = existsSync(paths.configFile);
+
+	return [
+		{
+			name: "agent-browser",
+			ok: ab.installed,
+			required: false,
+			detail: ab.installed ? (ab.version ?? "installed") : "not on PATH",
+			hint: ab.installed ? undefined : ab.hint,
+		},
+		{
+			name: "node",
+			ok: true,
+			required: true,
+			detail: process.version,
+		},
+		{
+			name: "config",
+			ok: configured,
+			required: false,
+			detail: configured ? paths.configFile : "not created yet",
+			hint: configured ? undefined : "Run: sunat-cli login",
+		},
+	];
+}
+
+export function createDoctorCommand(): Command {
+	return new Command("doctor")
+		.description("Check what this CLI needs to run: dependencies, config, sessions. T0.")
+		.action(function (this: Command) {
+			const format = this.parent?.opts().output || "auto";
+			const results = checks();
+			const failed = results.filter((c) => !c.ok);
+			const blocking = failed.filter((c) => c.required);
+
+			if (isHumanFormat(format)) {
+				const glyph = blocking.length > 0 ? danger("●") : failed.length > 0 ? warn("●") : ok("●");
+				const verdict =
+					blocking.length > 0
+						? "cannot run"
+						: failed.length > 0
+							? `ready, ${failed.length} optional ${failed.length === 1 ? "piece" : "pieces"} missing`
+							: "ready";
+				console.log(`${glyph} sunat-cli ${verdict}`);
+				console.log();
+				for (const c of results) {
+					const mark = c.ok ? ok("✓") : c.required ? danger("✗") : warn("○");
+					console.log(`  ${mark} ${c.name.padEnd(15)} ${muted(c.detail)}`);
+					if (c.hint) {
+						for (const line of c.hint.split("\n")) console.log(dim(`      ${line}`));
+					}
+				}
+				return;
+			}
+
+			output(format, {
+				json: {
+					ok: blocking.length === 0,
+					checks: results.map((c) => ({
+						name: c.name,
+						ok: c.ok,
+						required: c.required,
+						detail: c.detail,
+						...(c.hint ? { hint: c.hint } : {}),
+					})),
+				},
+			});
+		});
+}

--- a/packages/cli/src/plataforma/session.ts
+++ b/packages/cli/src/plataforma/session.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { isMissingBinary, missingBinaryError } from "../browser/dependency.ts";
 import { privateChildEnv } from "../data/child-process.ts";
 import { paths } from "../data/config.ts";
 import { secureExistingFile, writePrivateFile } from "../data/private-storage.ts";
@@ -62,7 +63,7 @@ export async function captureIdCacheFromSession(): Promise<string> {
 		let out = "";
 		proc.stdout.on("data", (d: Buffer) => (out += d.toString()));
 		proc.on("close", (code) => (code === 0 ? resolve(out) : reject(new Error("network requests failed"))));
-		proc.on("error", reject);
+		proc.on("error", (err) => reject(isMissingBinary(err) ? missingBinaryError() : err));
 	});
 
 	const match = stripAnsi(requests).match(/idCache=(ey[A-Za-z0-9._-]+)/);

--- a/packages/cli/src/skills/core.md
+++ b/packages/cli/src/skills/core.md
@@ -4,7 +4,23 @@ SUNAT tax automation via `npx @crafter/sunat-cli` (or `sunat-cli` if globally in
 
 Install: `npm install -g @crafter/sunat-cli`. Runs on Node, no Bun needed.
 
-RHE and F616 additionally need [agent-browser](https://github.com/vercel-labs/agent-browser) and Chrome; CPE, SIRE and GRE need a SUNAT certificate and a clave SOL. Everything else works with neither.
+RHE, F616 and the portal scrapers drive a real browser through
+[agent-browser](https://github.com/vercel-labs/agent-browser), which is a
+separate binary rather than a bundled dependency:
+
+```bash
+npm install -g agent-browser      # all platforms
+brew install agent-browser        # macOS
+agent-browser install             # download Chrome, first time only
+```
+
+CPE, SIRE and GRE need a SUNAT certificate and a clave SOL instead. Everything
+else works with neither.
+
+**Run `sunat-cli doctor` first.** It reports what is present, what is missing,
+and the command that fixes each gap. A command that needs agent-browser and
+cannot find it fails naming the tool and how to install it, rather than
+reporting that navigation failed.
 
 Current beta posture: supervised RHE/F616 beta, not autonomous filing. Real SUNAT operations require `--yes --live-sunat`, should use `--preview-only` first, and must stop if preview values cannot be parsed or reconciled.
 

--- a/packages/cli/tests/unit/agent-browser-dependency.test.ts
+++ b/packages/cli/tests/unit/agent-browser-dependency.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import {
+	AGENT_BROWSER_INSTALL,
+	isMissingBinary,
+	missingBinaryError,
+	probeAgentBrowser,
+} from "../../src/browser/dependency.ts";
+
+describe("agent-browser as a declared dependency", () => {
+	test("ENOENT is recognised as a missing binary", () => {
+		const err = new Error("spawn agent-browser ENOENT") as NodeJS.ErrnoException;
+		err.code = "ENOENT";
+		expect(isMissingBinary(err)).toBe(true);
+	});
+
+	test("other spawn failures are not mistaken for a missing binary", () => {
+		const err = new Error("boom") as NodeJS.ErrnoException;
+		err.code = "EACCES";
+		expect(isMissingBinary(err)).toBe(false);
+		expect(isMissingBinary(undefined)).toBe(false);
+	});
+
+	test("the error names the cause and every install route", () => {
+		const msg = missingBinaryError().message;
+		expect(msg).toContain("agent-browser is not installed");
+		expect(msg).toContain("npm install -g agent-browser");
+		expect(msg).toContain("brew install agent-browser");
+		expect(msg).toContain("agent-browser install");
+		expect(msg).toContain("npx agent-browser");
+	});
+
+	test("the error carries a code a caller can branch on", () => {
+		expect((missingBinaryError() as NodeJS.ErrnoException).code).toBe("AGENT_BROWSER_MISSING");
+	});
+
+	test("every install route appears exactly once", () => {
+		for (const route of ["npm install -g", "brew install", "agent-browser install"]) {
+			expect(AGENT_BROWSER_INSTALL.split(route).length - 1).toBe(1);
+		}
+	});
+
+	test("the probe answers without throwing, installed or not", () => {
+		const status = probeAgentBrowser();
+		expect(typeof status.installed).toBe("boolean");
+		if (!status.installed) expect(status.hint).toBeTruthy();
+	});
+});

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -144,6 +144,10 @@ const featureHtmls = await Promise.all(features.map((f) => codeToHtml(f.code, { 
 const heroCode = `# Install globally. Runs on Node, no Bun needed
 $ npm install -g @crafter/sunat-cli
 
+# Check what is present and what each gap needs
+$ sunat-cli doctor
+● sunat-cli ready  ✓ agent-browser  ✓ node  ✓ config
+
 # Introspect the schema, versioned so agents can pin it
 $ sunat-cli schema cpe-factura
 { "version": "1.0.0", "command": "cpe factura emit", "fields": {...} }


### PR DESCRIPTION
`agent-browser` was spawned by name and declared nowhere: not in `dependencies`, not in `peerDependencies`, and no command checked for it. Four namespaces depend on it across five spawn sites.

When it was absent, this is what a user got:

```
$ sunat-cli f616 periodo 2026-03
{ "success": false, "error": "Browser navigation failed" }
```

That names neither the cause nor the fix. It is the same failure shape as the `bun` shebang that 0.10.0 removed, and it became more likely because of that release: installing no longer requires Bun, so a clean `npm install -g` now reaches people who never had the tool.

## What changed

**The spawn sites translate ENOENT.** Same command, after:

```
{
  "success": false,
  "error": "agent-browser is not installed. RHE, F616 and the portal scrapers drive a real browser through it.\n\n  npm install -g agent-browser      # all platforms\n  brew install agent-browser        # macOS\n  agent-browser install             # download Chrome, first time only\n\nOr run it once without installing: npx agent-browser open example.com"
}
```

The error carries `code: AGENT_BROWSER_MISSING` so a caller can branch on it rather than matching the string.

**A root `doctor` command.** `cpe doctor` existed but only covers the CPE driver.

```
● sunat-cli ready, 2 optional pieces missing

  ○ agent-browser   not on PATH
      npm install -g agent-browser      # all platforms
      brew install agent-browser        # macOS
      agent-browser install             # download Chrome, first time only
  ✓ node            v24.3.0
  ○ config          not created yet
      Run: sunat-cli login
```

Amber for an optional gap, red reserved for something that blocks. JSON under a pipe, like everything else.

**Declared as an optional peerDependency**, so the requirement is visible to the package manager instead of living only in prose.

**README, the site and the agent manual** carry all four install routes.

## Verification

Ran a command that needs the browser with `agent-browser` off PATH, before and after, and the message changed from the navigation error to the one above. `doctor` exercised in both states, and in the built Node artifact.

The tests were falsified by breaking the detector, which turns one red rather than leaving all six passing.

464 pass, 0 fail. Website builds.