### PR TITLE
chore(release): 0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3774,7 +3774,7 @@
 		},
 		"packages/cli": {
 			"name": "@crafter/sunat-cli",
-			"version": "0.10.1",
+			"version": "0.11.0",
 			"license": "MIT",
 			"dependencies": {
 				"@clack/prompts": "^1.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/sunat-cli",
-	"version": "0.10.1",
+	"version": "0.11.0",
 	"description": "Agent-first CLI for SUNAT tax automation",
 	"module": "bin/sunat.ts",
 	"type": "module",


### PR DESCRIPTION
Ships the agent-browser dependency contract from #81.

Minor rather than patch: `doctor` is a new command, and the error a caller sees when agent-browser is missing changes shape, gaining a `code` field callers can branch on.

464 pass, 0 fail.