### PR TITLE
fix(skills): make the installer prompt actually work

### DIFF
--- a/packages/cli/skills/sunat-cli/SKILL.md
+++ b/packages/cli/skills/sunat-cli/SKILL.md
@@ -7,7 +7,7 @@ description: SUNAT tax automation CLI for Peru. Three namespaces. (A) Personas n
 
 SUNAT tax automation via `npx @crafter/sunat-cli` (or `sunat-cli` if globally installed).
 
-Install: `npx skills add Railly/sunat-cli -g`
+Install: `npx skills add crafter-research/sunat-cli -g`
 
 ## Auth
 

--- a/packages/cli/src/utils/skill.ts
+++ b/packages/cli/src/utils/skill.ts
@@ -19,7 +19,7 @@ export async function installSkill(canPrompt: boolean): Promise<boolean> {
 	});
 
 	if (p.isCancel(install) || !install) {
-		p.log.info("Skipped. Install later: npx skills add Railly/sunat-cli -g");
+		p.log.info("Skipped. Install later: npx skills add crafter-research/sunat-cli -g");
 		return false;
 	}
 
@@ -28,7 +28,7 @@ export async function installSkill(canPrompt: boolean): Promise<boolean> {
 		// throw, so the failure path is a rejected promise instead of the catch
 		// arm reached under a synchronous spawn.
 		const exitCode = await new Promise<number>((resolve, reject) => {
-			const proc = spawn("npx", ["skills", "add", "Railly/sunat-cli", "-g"], {
+			const proc = spawn("npx", ["skills", "add", "crafter-research/sunat-cli", "-g"], {
 				env: privateChildEnv(process.env, [
 					"HTTPS_PROXY",
 					"HTTP_PROXY",
@@ -44,7 +44,7 @@ export async function installSkill(canPrompt: boolean): Promise<boolean> {
 		});
 		return exitCode === 0;
 	} catch {
-		p.log.warn("npx skills not available. Install manually: npx skills add Railly/sunat-cli -g");
+		p.log.warn("npx skills not available. Install manually: npx skills add crafter-research/sunat-cli -g");
 		return false;
 	}
 }

--- a/skills/sunat-cli/SKILL.md
+++ b/skills/sunat-cli/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: sunat-cli
+description: "SUNAT tax automation for Peru from the terminal. Use when the user mentions SUNAT, RHE, recibo por honorarios, F616, renta anual, F709, factura or boleta electronica, CPE, SIRE, padron RUC, tipo de cambio SUNAT, or says emitir recibo, emitir factura, declarar F616, anular comprobante, impuestos Peru. Personas naturales with RUC 10 and empresas with RUC 20. Package @crafter/sunat-cli on npm."
+---
+
+# sunat-cli
+
+SUNAT tax automation from the terminal, for agents to operate and humans to supervise.
+
+Install: `npm install -g @crafter/sunat-cli`. Runs on Node, no Bun needed.
+
+## Read the manual from the binary, not from here
+
+This file exists so `npx skills add crafter-research/sunat-cli` finds something at
+the repository root. It is a pointer, not the guide. The real content ships with
+the CLI and always matches the version you have installed:
+
+```bash
+sunat-cli skills get core        # auth, RHE, F616, CPE, workflows
+sunat-cli skills get schemas     # field specs per command
+sunat-cli skills get endpoints   # the SUNAT endpoint behind each command
+sunat-cli skills list
+```
+
+Serving docs from the binary is the point: a copy pasted into an agent directory
+months ago describes a CLI that no longer exists, and nothing tells the reader it
+drifted.
+
+## Before anything else
+
+```bash
+sunat-cli doctor    # what is installed, what is missing, and the command that fixes it
+```
+
+RHE, F616 and the portal scrapers drive a real browser through
+[agent-browser](https://github.com/vercel-labs/agent-browser), a separate binary:
+
+```bash
+npm install -g agent-browser      # all platforms
+brew install agent-browser        # macOS
+agent-browser install             # download Chrome, first time only
+```
+
+CPE, SIRE and GRE need a SUNAT certificate and a clave SOL instead.
+
+## What it costs to get wrong
+
+Every mutation is graded and the grade is in `--help`: T0 reads, T1 writes
+locally, T2 files with SUNAT and needs `--yes`, T3 is irreversible and needs a
+single-use intent token. Preview before you file; `--dry-run` calls the real path.
+
+Production is beta throughout. Never run it blind.


### PR DESCRIPTION
`sunat-cli login` offers to install the agent skill. Saying yes failed twice over, and the second failure was hidden behind the first.

## The repository name was wrong

```
npx skills add Railly/sunat-cli -g
■  Failed to clone repository
   Authentication failed for https://github.com/Railly/sunat-cli.git.
     - For private repos, ensure you have access
```

That repository does not exist. The error sends the reader looking for missing access rather than a wrong name. The package lives at `crafter-research/sunat-cli`, which is public. Four occurrences.

## With the name fixed, the clone worked and still found nothing

`npx skills add` looks for `skills/<name>/SKILL.md` at the repository root, and the manual lives at `packages/cli/skills/`.

Three approaches were tried and discarded, each for a measured reason:

- **A root symlink.** Git stores it as a symlink and it survives a clone, but the installer does not follow it.
- **Moving the source to the root.** npm cannot pack outside the package directory, so the manual would drop out of the published tarball and break the `agent-manual` check.
- **Real directories in both places.** They had already diverged: `references/RESEARCH.md` existed in only one. Two files saying the same thing drift, which is the failure this repo has fixed three times.

So the root file is a **stub that points at the binary**, not a copy of the guide:

```bash
sunat-cli doctor              # what is installed and what each gap needs
sunat-cli skills get core     # the actual manual, matching your installed version
```

Serving docs from the CLI is deliberate. A copy pasted into an agent directory months ago describes a version that no longer exists, and nothing tells the reader it drifted.

## One thing worth recording

The first stub failed too, and not for the reason I expected. Reusing the package's own `description` verbatim produced invalid YAML: it carries backticks, parentheses and colons, and was not quoted. `skills add` reported the generic "No valid skills found", which reads as a missing file rather than a broken parse.

The stub now carries its own quoted description, verified to parse.

## Verification

Cloned the branch into a temp directory and ran `npx skills add` against it. It installs, and the installed file is the pointer, not a stale copy.

464 pass, 0 fail.