### PR TITLE
chore(release): 0.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3774,7 +3774,7 @@
 		},
 		"packages/cli": {
 			"name": "@crafter/sunat-cli",
-			"version": "0.11.0",
+			"version": "0.11.1",
 			"license": "MIT",
 			"dependencies": {
 				"@clack/prompts": "^1.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/sunat-cli",
-	"version": "0.11.0",
+	"version": "0.11.1",
 	"description": "Agent-first CLI for SUNAT tax automation",
 	"module": "bin/sunat.ts",
 	"type": "module",


### PR DESCRIPTION
Ships the installer fixes from #83.

`sunat-cli login` offers to install the agent skill, and accepting it failed: the command named `Railly/sunat-cli`, which does not exist, so the clone died with an authentication error that pointed the reader at missing access rather than a wrong name.

With the name corrected the clone succeeded and the installer still reported no skills found, because it looks for `skills/<name>/SKILL.md` at the repository root while the manual lives inside the package. The root now carries a stub that points at the binary instead of duplicating the guide, since two copies of the same content drift and these two already had.

Patch rather than minor: no command, flag or output shape changed.

464 pass, 0 fail.