### PR TITLE
fix(doctor): read the config path that exists

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -15,7 +15,7 @@ type Check = {
 
 function checks(): Check[] {
 	const ab = probeAgentBrowser();
-	const configured = existsSync(paths.configFile);
+	const configured = existsSync(paths.config);
 
 	return [
 		{
@@ -35,7 +35,7 @@ function checks(): Check[] {
 			name: "config",
 			ok: configured,
 			required: false,
-			detail: configured ? paths.configFile : "not created yet",
+			detail: configured ? paths.config : "not created yet",
 			hint: configured ? undefined : "Run: sunat-cli login",
 		},
 	];

--- a/packages/cli/tests/unit/doctor-paths.test.ts
+++ b/packages/cli/tests/unit/doctor-paths.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { paths } from "../../src/data/config.ts";
+
+describe("doctor reads paths that exist", () => {
+	test("every path doctor inspects is a string, not undefined", () => {
+		// existsSync(undefined) does not throw, it warns and returns false, so a
+		// typo in a field name reads as "not configured" forever rather than as
+		// an error. paths.configFile was such a typo and reported a present
+		// config as missing on every run.
+		expect(typeof paths.config).toBe("string");
+		expect(paths.config.length).toBeGreaterThan(0);
+	});
+
+	test("paths has no configFile field, which is the name that was wrong", () => {
+		expect("configFile" in paths).toBe(false);
+	});
+});


### PR DESCRIPTION
`doctor` checked `paths.configFile`. That field does not exist: the real name is `paths.config`.

`existsSync(undefined)` does not throw. It emits a deprecation warning and returns false, so the check reported a present config as missing on every run:

```
before   ○ config          not created yet
         (node:99596) [DEP0187] DeprecationWarning: Passing invalid argument
         types to fs.existsSync is deprecated

after    ✓ config          /Users/…/.sunat/config.json
```

Two things this got wrong at once: a wrong answer, and a Node warning printed underneath the command's own output.

Found by installing the published 0.11.1 and running it, not by reading the code. The warning only surfaces on Node, and the test suite runs under Bun, so nothing local would have shown it. That is the case for verifying against what ships.

The regression test asserts the field is a string and that `configFile` is absent from `paths`, so a future rename turns a test red instead of reporting "not created yet" forever.

466 pass, 0 fail.