### PR TITLE
chore(release): 0.11.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3774,7 +3774,7 @@
 		},
 		"packages/cli": {
 			"name": "@crafter/sunat-cli",
-			"version": "0.11.1",
+			"version": "0.11.2",
 			"license": "MIT",
 			"dependencies": {
 				"@clack/prompts": "^1.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/sunat-cli",
-	"version": "0.11.1",
+	"version": "0.11.2",
 	"description": "Agent-first CLI for SUNAT tax automation",
 	"module": "bin/sunat.ts",
 	"type": "module",


### PR DESCRIPTION
Ships the `doctor` fix from #85.

`doctor` read `paths.configFile`, which does not exist. `existsSync(undefined)` returns false rather than throwing, so the check reported a present config as missing on every run and printed a Node deprecation warning underneath its own output.

Found by installing the published 0.11.1 and running it. The warning only appears on Node and the suite runs under Bun, so nothing local would have caught it.

466 pass, 0 fail.