### PR TITLE
feat: the last three commands that printed JSON to a person

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
     },
     "packages/cli": {
       "name": "@crafter/sunat-cli",
-      "version": "0.10.0",
+      "version": "0.11.2",
       "bin": {
         "sunat-cli": "dist/sunat.js",
       },
@@ -28,6 +28,12 @@
         "@types/yauzl": "^3.4.0",
         "@types/yazl": "^3.3.1",
       },
+      "peerDependencies": {
+        "agent-browser": ">=0.22",
+      },
+      "optionalPeers": [
+        "agent-browser",
+      ],
     },
     "packages/website": {
       "name": "@crafter/sunat-cli-website",

--- a/packages/cli/src/commands/cpe/index.ts
+++ b/packages/cli/src/commands/cpe/index.ts
@@ -10,7 +10,7 @@ import { audit } from "../../data/audit.ts";
 import { loadConfig } from "../../data/config.ts";
 import { resolveSecret } from "../../data/keychain.ts";
 import { emitNextSteps, type NextStep } from "../../utils/next-steps.ts";
-import { isHumanFormat, output, outputError } from "../../utils/output.ts";
+import { isHumanFormat, output, outputError, outputTable } from "../../utils/output.ts";
 import { bold, danger, dim, info, muted, ok as okColor, padVisible, visibleWidth } from "../../utils/style.ts";
 
 type Format = "json" | "table" | "auto";
@@ -1030,6 +1030,31 @@ export function createCpeCommand(): Command {
 			const format = getFormat(cmd);
 			try {
 				const config = loadCpeConfig();
+				if (isHuman(format)) {
+					const names = Object.keys(config.profiles ?? {});
+					if (names.length === 0) {
+						console.log(muted("No emisor profiles configured."));
+						console.log(dim("  Create one: sunat-cli cpe profile set --name <name> --ruc <ruc> --razon-social <name>"));
+					} else {
+						// The active profile is what a reader is checking for, so it
+						// carries a marker rather than being one row among equals.
+						outputTable(
+							["", "Profile", "RUC", "Razon social", "Mode"],
+							names.map((n) => {
+								const p = config.profiles[n];
+								const active = n === config.defaultProfile;
+								return [
+									active ? okColor("●") : dim("○"),
+									active ? bold(n) : n,
+									p?.emisor?.ruc ?? "-",
+									p?.emisor?.razonSocial ?? "-",
+									p?.mode ?? "-",
+								];
+							}),
+						);
+					}
+					return;
+				}
 				output(format, { json: { defaultProfile: config.defaultProfile || null, profiles: config.profiles } });
 			} catch (err) {
 				outputError(err instanceof Error ? err.message : String(err), format);

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -2,8 +2,51 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Command } from "commander";
 import { getCpeCatalogosSchema } from "../cpe/catalogos/index.ts";
-import { outputJSON } from "../utils/output.ts";
+import { isHumanFormat, outputJSON, outputTable } from "../utils/output.ts";
 import { packageDataDir } from "../utils/package-data.ts";
+import { bold, danger, dim, muted, truncateVisible } from "../utils/style.ts";
+
+/**
+ * A person asking for a schema wants to know which fields exist, which are
+ * mandatory and what shape they take. Printing the contract verbatim answers
+ * that, but only after the reader parses braces by eye.
+ *
+ * The machine contract is untouched: this branch runs only on a terminal, and
+ * `-o json` or a pipe still emits the exact document an agent parses.
+ */
+function renderSchema(doc: Record<string, unknown>): void {
+	const version = typeof doc.version === "string" ? doc.version : "?";
+	const command = typeof doc.command === "string" ? doc.command : "";
+	const description = typeof doc.description === "string" ? doc.description : "";
+
+	console.log(`${bold(command || "schema")}  ${muted(`contract v${version}`)}`);
+	if (description) console.log(dim(`  ${description}`));
+
+	const fields = doc.fields as Record<string, Record<string, unknown>> | undefined;
+	if (!fields || Object.keys(fields).length === 0) {
+		console.log();
+		console.log(muted("This resource carries no field table. Use -o json to read it whole."));
+		return;
+	}
+
+	console.log();
+	const rows = Object.entries(fields).map(([name, spec]) => {
+		const required = spec?.required === true;
+		const def = spec?.default;
+		return [
+			required ? danger("*") : dim(" "),
+			name,
+			String(spec?.type ?? "-"),
+			def === undefined ? dim("-") : String(def),
+			muted(truncateVisible(String(spec?.description ?? ""), 52)),
+		];
+	});
+	outputTable(["", "Field", "Type", "Default", "Description"], rows);
+	console.log();
+	console.log(
+		dim(`  ${danger("*")} required · full contract: sunat-cli schema ${command.split(" ")[0] || ""} -o json`),
+	);
+}
 
 const SCHEMAS_DIR = packageDataDir("schemas");
 
@@ -42,7 +85,8 @@ export function createSchemaCommand(): Command {
 	return new Command("schema")
 		.description("Introspect command schemas (agent self-service)")
 		.argument("<resource>", `Resource to describe: ${AVAILABLE_SCHEMAS.join(", ")}`)
-		.action((resource: string) => {
+		.action(function (this: Command, resource: string) {
+			const fmt = () => (this.parent?.opts().output as string | undefined) ?? "auto";
 			if (resource === "login") {
 				outputJSON(
 					withVersion("login", {
@@ -70,14 +114,22 @@ export function createSchemaCommand(): Command {
 			}
 
 			if (resource === "cpe-catalogos") {
-				outputJSON(withVersion("cpe-catalogos", getCpeCatalogosSchema()));
+				{
+					const doc = withVersion("cpe-catalogos", getCpeCatalogosSchema());
+					if (isHumanFormat(fmt())) renderSchema(doc as Record<string, unknown>);
+					else outputJSON(doc);
+				}
 				return;
 			}
 
 			const schemaPath = join(SCHEMAS_DIR, `${resource}.json`);
 			try {
 				const schema = JSON.parse(readFileSync(schemaPath, "utf-8"));
-				outputJSON(withVersion(resource as SchemaName, schema));
+				{
+					const doc = withVersion(resource as SchemaName, schema);
+					if (isHumanFormat(fmt())) renderSchema(doc as Record<string, unknown>);
+					else outputJSON(doc);
+				}
 			} catch {
 				console.error(`Unknown schema: "${resource}". Available: ${AVAILABLE_SCHEMAS.join(", ")}`);
 				process.exit(1);

--- a/packages/cli/src/commands/tipo-cambio.ts
+++ b/packages/cli/src/commands/tipo-cambio.ts
@@ -1,7 +1,19 @@
 import { Command } from "commander";
 import { audit } from "../data/audit.ts";
 import { getTipoCambio, loadCachedTc } from "../sunat-rest/tipo-cambio.ts";
-import { output, outputError } from "../utils/output.ts";
+import { isHumanFormat, output, outputError } from "../utils/output.ts";
+import { bold, dim, muted } from "../utils/style.ts";
+
+/**
+ * The rate is what a person came for, so it leads. Compra and venta sit
+ * side by side because the gap between them is the thing a reader compares,
+ * and the date is context rather than the answer.
+ */
+function renderRate(rate: { fecha: string; compra: number; venta: number; moneda?: string }): void {
+	const moneda = rate.moneda ?? "USD";
+	console.log(`${bold(`S/ ${rate.venta.toFixed(3)}`)} venta   ${bold(`S/ ${rate.compra.toFixed(3)}`)} compra`);
+	console.log(dim(`  ${moneda} · ${rate.fecha} · fuente SUNAT`));
+}
 
 type Format = "json" | "table" | "auto";
 
@@ -37,6 +49,10 @@ export function createTipoCambioCommand(): Command {
 					result: "success",
 					details: { fecha: rate.fecha, compra: rate.compra, venta: rate.venta },
 				});
+				if (isHumanFormat(format)) {
+					renderRate(rate);
+					return;
+				}
 				output(format, { json: rate });
 			} catch (err) {
 				outputError(err instanceof Error ? err.message : String(err), format);
@@ -49,9 +65,19 @@ export function createTipoCambioCommand(): Command {
 		.action((opts, cmd) => {
 			const format = getFormat(cmd);
 			try {
-				if (opts.fecha) {
-					const r = loadCachedTc(opts.fecha);
-					output(format, { json: r ? { found: true, ...r } : { found: false, fecha: opts.fecha } });
+				// `--fecha` is declared on both this command and its parent, and
+				// Commander binds it to the parent, so reading only opts.fecha
+				// left it empty and the command rejected a flag the caller had
+				// actually passed.
+				const fecha = opts.fecha || cmd.parent?.opts().fecha;
+				if (fecha) {
+					const r = loadCachedTc(fecha);
+					if (isHumanFormat(format)) {
+						if (r) renderRate(r);
+						else console.log(muted(`Sin tipo de cambio en cache para ${fecha}`));
+						return;
+					}
+					output(format, { json: r ? { found: true, ...r } : { found: false, fecha } });
 					return;
 				}
 				outputError("--fecha required for 'cached' (full cache list shaped, not implemented)", format);

--- a/packages/cli/tests/e2e/human-views-round-3.test.ts
+++ b/packages/cli/tests/e2e/human-views-round-3.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+
+const BIN = new URL("../../bin/sunat.ts", import.meta.url).pathname;
+
+async function run(args: string[]): Promise<string> {
+	const proc = Bun.spawn(["bun", "run", BIN, ...args], { stdout: "pipe", stderr: "ignore" });
+	const out = await new Response(proc.stdout).text();
+	await proc.exited;
+	return out;
+}
+
+describe("a terminal run is not the machine contract", () => {
+	// -o table is the human branch without needing a pty. A pipe already
+	// exercises the machine branch, so the pair covers both directions.
+	for (const cmd of [
+		["schema", "f616"],
+		["tipo-cambio", "cached", "--fecha", "2026-08-20"],
+		["cpe", "profile", "list"],
+	]) {
+		test(`${cmd.join(" ")} renders a human view rather than JSON`, async () => {
+			const human = await run([...cmd, "-o", "table"]);
+			expect(() => JSON.parse(human)).toThrow();
+		});
+
+		test(`${cmd.join(" ")} keeps its machine contract under a pipe`, async () => {
+			const piped = await run(cmd);
+			const explicit = await run([...cmd, "-o", "json"]);
+			expect(piped).toBe(explicit);
+			expect(() => JSON.parse(piped)).not.toThrow();
+		});
+	}
+});


### PR DESCRIPTION
Swept every read-only command on a real terminal and compared it against the same command through a pipe. Three still emitted the machine contract to a human. Every other one already had a view.

## What changed

**`schema`** printed the contract verbatim, so reading it meant parsing braces by eye. It now prints a field table:

```
f616 declare  contract v1.0.0
  File Formulario Virtual 616 monthly tax declaration for 4ta categoria workers

   Field        Type    Default  Description
─  ───────────  ──────  ───────  ────────────────────────────────────
*  periodo      string  -        Tax period (e.g. 2025-10 for October…
   retenciones  number  0        Ignored, same reason as ingresoPEN.…

  * required · full contract: sunat-cli schema f616 -o json
```

**`tipo-cambio`** leads with the venta rate, which is what a person came for, and keeps the date as context rather than as the answer.

**`cpe profile list`** is a list, so it gets a table, with the active profile marked rather than being one row among equals.

## Machine contracts unchanged

Verified byte-identical against `main` for all eight schema resources and for both other commands. `-o json` and a pipe emit exactly what they did before.

## A real bug the new tests caught

`tipo-cambio cached --fecha 2026-08-20` rejected the flag it had just been given:

```
before  { "success": false, "error": "--fecha required for 'cached'" }
after   { "found": false, "fecha": "2026-08-20" }
```

`--fecha` is declared on both `tipo-cambio` and its `cached` subcommand, and Commander binds it to the parent, so the child read an empty value. Same class as the arity bug that made `cpe driver list` crash: an option resolved from the wrong place in the command tree.

## On the audit check

I tried to make `human-default-view` mechanical, since comparing a pty run against a pipe is measurable even though judging whether a view reads *well* is not. Six attempts, each blocked by a different real cause: `[options]` in every usage line defeating the argument filter, `script` needing a shell rather than an argument list, macOS emitting a literal `^D`, the probe about to run `login`, and `script` returning nothing through command substitution.

It still reported SKIP against a CLI I had just measured by hand, so I reverted it rather than ship a check that always abstains. The finding stands on the manual sweep; the automation does not.

472 pass, 0 fail.