### PR TITLE
chore(release): 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3774,7 +3774,7 @@
 		},
 		"packages/cli": {
 			"name": "@crafter/sunat-cli",
-			"version": "0.11.2",
+			"version": "0.12.0",
 			"license": "MIT",
 			"dependencies": {
 				"@clack/prompts": "^1.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/sunat-cli",
-	"version": "0.11.2",
+	"version": "0.12.0",
 	"description": "Agent-first CLI for SUNAT tax automation",
 	"module": "bin/sunat.ts",
 	"type": "module",


### PR DESCRIPTION
Ships #87.

Every read-only command now renders a human view on a terminal. `schema`, `tipo-cambio` and `cpe profile list` were the last three printing the machine contract to a person; machine contracts are byte-identical.

Also fixes `tipo-cambio cached --fecha`, which rejected the flag it had just been given.

Minor rather than patch: what a terminal shows changes for three commands, even though no piped output does.

472 pass, 0 fail.