### PR TITLE
fix(release): retry the lockfile install too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,18 @@ jobs:
           done
           test "$(./node_modules/.bin/sunat-cli --version)" = "$VERSION"
           ./node_modules/.bin/sunat-cli --help | grep -q "cpe"
-          npm install --ignore-scripts --package-lock-only "@crafter/sunat-cli@$VERSION" --registry https://registry.npmjs.org
+          # The lockfile resolution hits the registry too, and it was the one
+          # install in this step still lacking a retry. 0.12.0 failed here with
+          # ETARGET while the install above it, which does retry, had already
+          # succeeded: the same propagation delay, caught by the one line that
+          # was not guarded.
+          for attempt in $(seq 1 15); do
+            if npm install --ignore-scripts --package-lock-only "@crafter/sunat-cli@$VERSION" --registry https://registry.npmjs.org; then
+              break
+            fi
+            test "$attempt" != "15"
+            sleep 20
+          done
           npm audit signatures
 
       # Runs even when a check above failed. Publish happens before any of


### PR DESCRIPTION
0.12.0 failed at `Verify published artifact`:

```
npm error code ETARGET
npm error notarget No matching version found for @crafter/sunat-cli@0.12.0.
```

Same registry propagation delay a previous fix was meant to close. That fix wrapped the install one line above and left the lockfile resolution bare, so the step still died on a package that was already published and correct.

Every registry call in the step now retries on the same schedule. Four loops, one per call.

The tag and release did land, because the tag step runs on `always()`. That guard is doing exactly what it was added for: the failure is visible in the job, and the release is not left half-done.