### PR TITLE
fix(tipo-cambio): send Accept-Encoding, which SUNAT's WAF requires

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,8 @@
 		"test:e2e": "bun test tests/e2e",
 		"smoke:sunat": "bash scripts/smoke-sunat.sh",
 		"smoke:boleta": "bash scripts/smoke-boleta.sh",
-		"smoke:padron": "bash scripts/smoke-padron.sh"
+		"smoke:padron": "bash scripts/smoke-padron.sh",
+		"smoke:tipo-cambio": "bash scripts/smoke-tipo-cambio.sh"
 	},
 	"dependencies": {
 		"@clack/prompts": "^1.1.0",

--- a/packages/cli/scripts/smoke-tipo-cambio.sh
+++ b/packages/cli/scripts/smoke-tipo-cambio.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Smoke test: fetch a tipo de cambio from SUNAT with the build that ships.
+#
+# The WAF in front of e-consulta.sunat.gob.pe rejects requests that carry no
+# Accept-Encoding header. Bun's fetch adds one on its own; Node's does not. So
+# this test deliberately runs dist/sunat.js under node, not bin/sunat.ts under
+# bun: the failure it guards against only exists in the published artifact.
+#
+# Run from packages/cli directory:
+#   bash scripts/smoke-tipo-cambio.sh [YYYY-MM-DD]
+# Or via npm script:
+#   bun smoke:tipo-cambio
+#
+# No credentials needed: the endpoint is public.
+
+set -euo pipefail
+
+# A scratch state root, so the request is not answered from an operator's
+# cache: a cache hit would pass this test without touching the network.
+export SUNAT_HOME="$(mktemp -d "${TMPDIR:-/tmp}/sunat-smoke-tc.XXXXXX")"
+trap 'rm -rf "$SUNAT_HOME"' EXIT
+
+FECHA="${1:-$(date -v-7d +%F 2>/dev/null || date -d '7 days ago' +%F)}"
+
+echo "→ Building dist/sunat.js..."
+bun run scripts/build.ts >/dev/null
+
+echo "→ node dist/sunat.js tipo-cambio --fecha $FECHA (fresh SUNAT_HOME, no cache)..."
+# Errors are reported as JSON on stderr; capture both streams so the verdict
+# below reads the real answer rather than an empty string.
+RESULT=$(node dist/sunat.js -o json tipo-cambio --fecha "$FECHA" 2>&1 || true)
+echo "$RESULT" | bun -e '
+const r = JSON.parse(await Bun.stdin.text());
+if (r.success === false) {
+  console.log("  error:", r.error);
+  console.log("\n❌ TIPO-CAMBIO SMOKE FAILED");
+  process.exit(1);
+}
+console.log("  fecha:", r.fecha);
+console.log("  compra:", r.compra);
+console.log("  venta:", r.venta);
+if (typeof r.venta === "number" && r.venta > 0) {
+  console.log("\n✅ TIPO-CAMBIO SMOKE PASSED");
+  process.exit(0);
+}
+console.log("\n❌ TIPO-CAMBIO SMOKE FAILED: no venta rate in response");
+process.exit(1);
+'

--- a/packages/cli/scripts/smoke-tipo-cambio.sh
+++ b/packages/cli/scripts/smoke-tipo-cambio.sh
@@ -1,22 +1,7 @@
 #!/usr/bin/env bash
-# Smoke test: fetch a tipo de cambio from SUNAT with the build that ships.
-#
-# The WAF in front of e-consulta.sunat.gob.pe rejects requests that carry no
-# Accept-Encoding header. Bun's fetch adds one on its own; Node's does not. So
-# this test deliberately runs dist/sunat.js under node, not bin/sunat.ts under
-# bun: the failure it guards against only exists in the published artifact.
-#
-# Run from packages/cli directory:
-#   bash scripts/smoke-tipo-cambio.sh [YYYY-MM-DD]
-# Or via npm script:
-#   bun smoke:tipo-cambio
-#
-# No credentials needed: the endpoint is public.
 
 set -euo pipefail
 
-# A scratch state root, so the request is not answered from an operator's
-# cache: a cache hit would pass this test without touching the network.
 export SUNAT_HOME="$(mktemp -d "${TMPDIR:-/tmp}/sunat-smoke-tc.XXXXXX")"
 trap 'rm -rf "$SUNAT_HOME"' EXIT
 
@@ -26,8 +11,6 @@ echo "→ Building dist/sunat.js..."
 bun run scripts/build.ts >/dev/null
 
 echo "→ node dist/sunat.js tipo-cambio --fecha $FECHA (fresh SUNAT_HOME, no cache)..."
-# Errors are reported as JSON on stderr; capture both streams so the verdict
-# below reads the real answer rather than an empty string.
 RESULT=$(node dist/sunat.js -o json tipo-cambio --fecha "$FECHA" 2>&1 || true)
 echo "$RESULT" | bun -e '
 const r = JSON.parse(await Bun.stdin.text());

--- a/packages/cli/src/sunat-rest/tipo-cambio.ts
+++ b/packages/cli/src/sunat-rest/tipo-cambio.ts
@@ -52,6 +52,9 @@ const BROWSER_HEADERS: Record<string, string> = {
 		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
 	Accept: "application/json, text/javascript, */*; q=0.01",
 	"Accept-Language": "es-ES,es;q=0.9,en;q=0.8",
+	// SUNAT's WAF rejects requests without Accept-Encoding. Bun's fetch adds it
+	// by default; Node's (undici) does not, so the Node build was rejected.
+	"Accept-Encoding": "gzip, deflate, br",
 	"Content-Type": "application/json; charset=utf-8",
 	"X-Requested-With": "XMLHttpRequest",
 	Referer: TC_PAGE,

--- a/packages/cli/src/sunat-rest/tipo-cambio.ts
+++ b/packages/cli/src/sunat-rest/tipo-cambio.ts
@@ -52,8 +52,6 @@ const BROWSER_HEADERS: Record<string, string> = {
 		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
 	Accept: "application/json, text/javascript, */*; q=0.01",
 	"Accept-Language": "es-ES,es;q=0.9,en;q=0.8",
-	// SUNAT's WAF rejects requests without Accept-Encoding. Bun's fetch adds it
-	// by default; Node's (undici) does not, so the Node build was rejected.
 	"Accept-Encoding": "gzip, deflate, br",
 	"Content-Type": "application/json; charset=utf-8",
 	"X-Requested-With": "XMLHttpRequest",

--- a/packages/cli/tests/unit/tipo-cambio.test.ts
+++ b/packages/cli/tests/unit/tipo-cambio.test.ts
@@ -81,9 +81,6 @@ describe("selectRateForDate — pure selector", () => {
 });
 
 describe("getTipoCambio — request shape", () => {
-	// SUNAT's WAF rejects the request when Accept-Encoding is absent. Bun's fetch
-	// adds the header on its own, Node's does not, so the published Node build
-	// failed on every call while the Bun-run suite stayed green.
 	test("sends Accept-Encoding, which the WAF requires", async () => {
 		const original = global.fetch;
 		let seen: Record<string, string> = {};

--- a/packages/cli/tests/unit/tipo-cambio.test.ts
+++ b/packages/cli/tests/unit/tipo-cambio.test.ts
@@ -1,9 +1,9 @@
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
-import { join } from "path";
 import { tmpdir } from "os";
-import { loadCachedTc, saveTc, selectRateForDate } from "../../src/sunat-rest/tipo-cambio.ts";
+import { join } from "path";
 import { paths } from "../../src/data/config.ts";
+import { getTipoCambio, loadCachedTc, saveTc, selectRateForDate } from "../../src/sunat-rest/tipo-cambio.ts";
 
 const CACHE_FILE = join(paths.sunatDir, "cache", "tipo-cambio.jsonl");
 const TEST_TAG_DATE = "2099-01-01"; // collision-proof — never a real TC date
@@ -77,6 +77,29 @@ describe("selectRateForDate — pure selector", () => {
 			row("02/12/2025", "3.510", "V"),
 		];
 		expect(selectRateForDate(rows, "2025-12-05")?.publicada).toBe("2025-12-02");
+	});
+});
+
+describe("getTipoCambio — request shape", () => {
+	// SUNAT's WAF rejects the request when Accept-Encoding is absent. Bun's fetch
+	// adds the header on its own, Node's does not, so the published Node build
+	// failed on every call while the Bun-run suite stayed green.
+	test("sends Accept-Encoding, which the WAF requires", async () => {
+		const original = global.fetch;
+		let seen: Record<string, string> = {};
+		global.fetch = (async (_url: unknown, init?: RequestInit) => {
+			seen = Object.fromEntries(new Headers(init?.headers).entries());
+			return new Response(JSON.stringify([row("01/01/2099", "3.500", "C"), row("01/01/2099", "3.510", "V")]), {
+				status: 200,
+			});
+		}) as typeof fetch;
+		try {
+			const rate = await getTipoCambio({ fecha: TEST_TAG_DATE, force: true });
+			expect(rate.venta).toBe(3.51);
+			expect(seen["accept-encoding"]).toContain("gzip");
+		} finally {
+			global.fetch = original;
+		}
 	});
 });
 


### PR DESCRIPTION
`tipo-cambio` fails on every call from the published build. The Node binary gets SUNAT's WAF page instead of the rates; the same code under `bun run` works, and the suite runs under Bun, so nothing local showed it.

The cause is one header. Bisecting the request headers against e-consulta.sunat.gob.pe, only `Accept-Encoding` changes the answer: with it the month's rates, without it the WAF rejection. Bun's `fetch` adds `Accept-Encoding: gzip, deflate, br` on its own; Node's sends none. The fix sends it explicitly, and the unit test mocks `fetch` and asserts the header goes out.

```
before  { "success": false, "error": "SUNAT WAF rejected the request. Headers may need updating." }
after   { "fecha": "2026-08-19", "compra": 3.352, "venta": 3.362 }
```

To verify, `bun smoke:tipo-cambio` builds `dist/sunat.js` and runs it under node with a fresh `SUNAT_HOME`, so a cached rate cannot pass it. The endpoint is public; no credentials. On `main`'s `tipo-cambio.ts` the same script reports the WAF rejection. Same failure class as #85: it only exists in what ships.

405 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
