### PR TITLE
feat(rhe): add endpoint-backed preview flow

### DIFF
--- a/packages/cli/LIMITATIONS.md
+++ b/packages/cli/LIMITATIONS.md
@@ -182,11 +182,11 @@ authorizes rather than a residual browser session.
 
 ## RHE / F616 — Personas Naturales (legacy, pre-existing)
 
-These predate the agent-first refactor and use the older agent-browser scraping path. Not part of recent PRs but documenting for completeness:
+These surfaces still need browser bootstrap, but RHE no longer fills identity and detail fields through DOM automation:
 
-- ⚠️ **Browser scraping** — uses `agent-browser` to drive the SOL portal directly. Brittle to UI changes. Currently working but expect maintenance.
+- ⚠️ **Browser boundary** — RHE uses direct HTTP through preview, but Menu SOL bootstrap and the final legal confirmation still depend on the headed portal.
 - ⚠️ **reCAPTCHA via mouse coordinates** — F616 (Nueva Plataforma) requires solving reCAPTCHA. Solved via coordinate injection. Documented as fragile in `CLAUDE.md`.
-- ✅ **RHE emission**: verified working against the SUNAT portal.
+- ⚠️ **RHE emission**: direct deduction, identity and details POSTs were replayed with varied inputs and rendered back into the live draft preview for `CONTADO` + `SIN DOCUMENTO`. `GrabaReciboHonorarios` was not called during implementation, so a new production emission is still unverified.
 - ✅ **F616 declaration**: verified working against the SUNAT portal.
 
 ---

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,11 +25,15 @@ Selected surfaces:
 ```bash
 sunat-cli login                          # Auth (no CAPTCHA)
 sunat-cli schema rhe                     # Introspect fields
-sunat-cli rhe emit --dry-run --json '{}' # Preview
-sunat-cli rhe emit --batch ./data.csv    # Batch emit
-sunat-cli f616 declare --dry-run --json '{"periodo":"2025-03"}'
+sunat-cli rhe emit --params '{"empresa":"Cliente","descripcion":"Servicio","monto":100}' --dry-run
+sunat-cli rhe emit --params '{"empresa":"Cliente","descripcion":"Servicio","monto":100}' --preview-only
+sunat-cli rhe emit --params '{"empresa":"Cliente","descripcion":"Servicio","monto":100}' --yes --live-sunat
+sunat-cli f616 declare --dry-run --params '{"periodo":"2025-03"}'
 sunat-cli api token --output json        # Validate OAuth2 credentials without printing the token
 ```
+
+RHE is hybrid: a headed SOL session mints the entry URL, direct HTTP reaches the
+legally invalid preview, and the final browser confirmation remains gated.
 
 ### Buzón SOL metadata (read-only)
 

--- a/packages/cli/RESEARCH.md
+++ b/packages/cli/RESEARCH.md
@@ -95,25 +95,37 @@ agent-browser eval "ejecuta('MenuInternetPlataforma.htm?action=iconExecute&code=
 
 ## RHE Emission Workflow (SOL viejo)
 
-### Form Structure (3 steps)
+Observed from an authorized Chrome HAR captured on 2026-08-26. The raw HAR stays
+outside the repository because it carries cookies, tokens, request bodies and tax
+data. SHA-256: `18ae5b873812b8386839a8dab7244e5d3242832295257f1fcda0613a9ce68710`.
 
-**Step 1: Pre-question**
-- "Deduccion adicional de renta (3 UIT)?" → "No" is pre-selected
-- Click "Continuar"
+All form transitions POST to
+`/ol-ti-itreciboelectronico/cpelec001Alias` inside the authenticated iframe:
 
-**Step 2: Client Info**
-- Tipo Documento: dropdown → select "SIN DOCUMENTO" for foreign companies
-- When SIN DOCUMENTO selected: numero field disables, nombre field enables
-- Fill empresa name in nombre field
-- Click "Continuar"
+| Stage | Action | Observed contract |
+|---|---|---|
+| Menu bootstrap | GET `accion=EmisionRHE` | fresh `p`, `tenc`, `prg`, `fecenv`, `usub` query bundle |
+| Deduction | `RHEDeduccion1` | `inddeduccion=0`, `deduccion=0` |
+| Identity | `CapturaDatosReciboHonorariosIdentidad` | `formaPago=CONTADO`, `tipdoc=-`, `nombrecliente` |
+| Details | `CapturaDatosReciboHonorarios` | `motivo`, `fecemi`, `cantidad`, `moneda`, `mediopago`, renta/payment indicators |
+| Submit | `GrabaReciboHonorarios` | reached only from the rendered `Emitir Recibo` preview |
+| Confirmation | rendered document | exposes download, print and `Registrar Pagos` controls |
 
-**Step 3: Service Details + Amount**
-Fields (refs change each load, find by type/label):
-- Descripcion: first enabled textbox in iframe
-- Medio de Pago: combobox containing "Seleccione Medio de Pago"
-- Moneda: combobox showing "SOL" (change to "DOLAR DE NORTE AMERICA" for USD)
-- Monto Total: textbox with value "0.0"
-- Click "Continuar" → preview → "Emitir"/"Aceptar" → confirmation
+The captured recipient path was `SIN DOCUMENTO`. RUC and DNI add a separate
+`Validar RUC o DNI` transition that was not present, so the CLI must not claim
+that path until another authorized capture proves it.
+
+The captured receipt used `CONTADO`, `PEN`, service not gratuito, fourth-category
+inciso A, no withholding, full payment at emission, and payment medium code
+`001`. Payment medium codes observed in the form run from `001` through `013`;
+the CLI maps its existing eight public values to `001` through `008`.
+
+Live recon showed that a fresh Menu SOL entry URL can bootstrap a separate HTTP
+session without importing browser cookies. The CLI keeps the authenticated
+browser open for supervision, sends deduction, identity and details directly by
+HTTP, renders the returned draft back into the iframe, then reconciles client,
+description, date, currency and totals. `GrabaReciboHonorarios` remains a DOM
+confirmation and runs only when both `--yes` and `--live-sunat` are present.
 
 ### Gotchas
 
@@ -122,17 +134,13 @@ Fields (refs change each load, find by type/label):
    agent-browser eval "window.onbeforeunload = null"
    ```
 
-2. **Iframes everywhere**: SOL wraps every form in an iframe. agent-browser reads refs inside iframes automatically — no frame switching needed.
+2. **Iframes everywhere**: SOL wraps the form in a cross-origin iframe. CDP supplies the execution context that carries the form-session cookies and renders the direct HTTP preview.
 
 3. **Backend endpoint**: POST `https://ww1.sunat.gob.pe/ol-ti-itreciboelectronico/cpelec001Alias`
 
-4. **Date restriction**: SUNAT allows max 2-3 days retroactive for RHE dates. For regularizacion, all RHEs get today's date.
+4. **Date restriction**: the observed portal accepts today or the previous two days. This is portal behavior, not a published SUNAT contract.
 
-5. **Medio de Pago values** (exact strings SUNAT expects):
-   - "Deposito en Cuenta"
-   - "Transferencia de Fondos"
-   - "Tarjeta de Debito"
-   - "Efectivo - por operaciones donde no existe obligacion de utilizar Medios de Pago"
+5. **Medio de Pago values** are submitted as codes. `001` is deposit, `003` transfer, `005` debit card and `008` cash where no payment-medium obligation exists.
 
 ---
 
@@ -246,11 +254,11 @@ The JWT payload contains the API base URLs:
 | GRE Emision Comprobantes | `/v1/contribuyente/gem` | Guias de Remision (NOT RHE) |
 | MIGE RCE y RVIE - SIRE | `/v1/contribuyente/migeigv` | Registro compras/ventas |
 
-### Important: No RHE API Exists
+### Important: No public RHE issuance API exists
 
-The GRE (Guia de Remision Electronica) endpoint is for shipping guides, **not** Recibos por Honorarios. There is no public REST API for emitting RHE — browser automation is the only way.
+The GRE (Guia de Remision Electronica) endpoint is for shipping guides, **not** Recibos por Honorarios. SUNAT does not publish a REST API for issuing RHE. The legacy issuer is nevertheless a replayable, stateful HTML endpoint through the legally invalid preview. Menu SOL must still mint the entry URL, and the final legal confirmation stays supervised in the browser.
 
-The API is useful for **verification** after emitting RHE via browser.
+The public API remains useful for **verification** after issuance.
 
 ---
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/sunat-cli",
-	"version": "0.13.0",
+	"version": "0.14.0",
 	"description": "Agent-first CLI for SUNAT tax automation",
 	"module": "bin/sunat.ts",
 	"type": "module",

--- a/packages/cli/skills/sunat-cli/SKILL.md
+++ b/packages/cli/skills/sunat-cli/SKILL.md
@@ -43,36 +43,37 @@ Linux stores secrets through `secret-tool` / libsecret.
 ### RHE (Recibo por Honorarios)
 
 ```bash
-# Emit single RHE
+# Build and reconcile one RHE draft in SUNAT
 sunat-cli rhe emit --params '{
   "empresa": "Cliente Ejemplo",
   "tipoDoc": "SIN DOCUMENTO",
   "descripcion": "Servicios de desarrollo de software",
   "monto": 6700,
-  "moneda": "USD",
+  "moneda": "PEN",
   "medioPago": "TRANSFERENCIA"
-}'
+}' --preview-only
 
-# Preview without submitting
+# Validate locally without opening SUNAT
 sunat-cli rhe emit --params '...' --dry-run
 
-# Batch from CSV
-sunat-cli rhe emit --batch recibos.csv
+# Reach SUNAT's server preview by direct HTTP and render it for review
+sunat-cli rhe emit --params '...' --preview-only
 
-# List issued RHEs
-sunat-cli rhe list
+# Emit only after visually checking the preview
+sunat-cli rhe emit --params '...' --yes --live-sunat
 
-# Verify registration
-sunat-cli rhe verify --month 2026-03
+# Validate a CSV batch locally
+sunat-cli rhe emit --batch recibos.csv --dry-run
 ```
 
 **RHE fields**: See `references/schemas.md` for full field specs.
 
 Key rules:
-- `tipoDoc`: Use `SIN DOCUMENTO` for foreign companies (no RUC/DNI)
-- `moneda`: USD auto-converts to PEN at SUNAT exchange rate
-- `fechaEmision`: Max 2-3 days retroactive
-- Auth: SOL viejo portal, no captcha
+- `tipoDoc`: Only `SIN DOCUMENTO` is verified. RUC/DNI need a separate authorized capture.
+- `fechaEmision`: Sent as DD/MM/YYYY and reconciled against the rendered preview. The observed portal accepts today or the previous 2 days.
+- The observed path is `CONTADO`, non-gratuito, inciso A, no withholding and fully paid at emission.
+- Auth: headed SOL bootstrap; direct HTTP through preview; browser confirmation for the final legal submission.
+- Live batches are disabled. Validate CSV with `--dry-run`, then preview and emit each RHE individually.
 
 ### F616 (Monthly Tax Declaration)
 
@@ -550,8 +551,8 @@ not as an error.
 
 **Emit an RHE**:
 1. `sunat-cli login`
-2. `sunat-cli rhe emit --params '{"empresa":"Cliente Ejemplo","tipoDoc":"SIN DOCUMENTO","descripcion":"Servicios de desarrollo de software - Marzo 2026","monto":6700,"moneda":"USD","medioPago":"TRANSFERENCIA"}'`
-3. `sunat-cli rhe verify --month 2026-03`
+2. `sunat-cli rhe emit --params '{"empresa":"Cliente Ejemplo","tipoDoc":"SIN DOCUMENTO","descripcion":"Servicios de desarrollo de software - Agosto 2026","monto":6700,"moneda":"PEN","medioPago":"TRANSFERENCIA"}' --preview-only`
+3. Check the headed browser, then rerun with `--yes --live-sunat`
 
 ## Error Handling
 

--- a/packages/cli/skills/sunat-cli/references/schemas.md
+++ b/packages/cli/skills/sunat-cli/references/schemas.md
@@ -5,14 +5,18 @@
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | empresa | string(100) | yes | - | Company/person name receiving the service |
-| tipoDoc | enum | no | SIN DOCUMENTO | SIN DOCUMENTO, RUC, DNI, CARNET DE EXTRANJERIA, PASAPORTE, CED. DIPLOMATICA DE IDENTIDAD |
+| tipoDoc | enum | no | SIN DOCUMENTO | Only SIN DOCUMENTO is verified. RUC/DNI require an uncaptured validation transition. |
 | descripcion | string(200) | yes | - | Service description |
-| monto | number | yes | - | Total amount (0.01-1000000). USD auto-converts to PEN |
+| monto | number | yes | - | Total amount (0.01-1000000). The captured flow used PEN; preview USD before live use. |
 | moneda | enum | no | PEN | PEN or USD |
 | medioPago | enum | no | TRANSFERENCIA | DEPOSITO, GIRO, TRANSFERENCIA, ORDEN DE PAGO, TARJETA DEBITO, TARJETA CREDITO, CHEQUE, EFECTIVO |
-| fechaEmision | date | no | today | YYYY-MM-DD. Max 2-3 days retroactive |
+| fechaEmision | date | no | today | YYYY-MM-DD. Written as DD/MM/YYYY. The observed portal accepts today or the previous 2 days. |
 
 Portal: SOL viejo (e-menu.sunat.gob.pe/cl-ti-itmenu/) -- no captcha.
+
+`--dry-run` validates locally. `--preview-only` sends the stateful form endpoint
+through the server draft, renders it in the iframe and stops at the reconciled
+`Emitir Recibo` page. Submission requires `--yes --live-sunat`.
 
 ## F616 Declare Fields
 

--- a/packages/cli/src/commands/rhe/index.ts
+++ b/packages/cli/src/commands/rhe/index.ts
@@ -6,6 +6,7 @@ import { getCredentials } from "../../data/config.ts";
 import { resolveParams } from "../../utils/deprecation.ts";
 import { output, outputError } from "../../utils/output.ts";
 import {
+	rejectControlChars,
 	sanitizePath,
 	validateEmpresa,
 	validateMedioPago,
@@ -24,35 +25,35 @@ export function createRheCommand(): Command {
 		.option("--params <json>", "JSON payload (see: sunat-cli schema rhe)")
 		.option("--json <payload>", "Deprecated alias for --params, will be removed in a later 0.x release")
 		.option("--batch <file>", "CSV file with multiple RHEs")
-		.option("--dry-run", "Preview without submitting")
+		.option("--dry-run", "Validate locally without opening SUNAT")
+		.option("--preview-only", "Fill SUNAT and stop at the reconciled preview")
+		.option("--yes", "Confirm the requested live operation")
+		.option("--live-sunat", "Acknowledge that this writes to production SUNAT")
 		.action(async (opts, cmd) => {
 			const format = cmd.parent?.parent?.opts().output || "auto";
 			const dryRun = opts.dryRun || false;
+			const previewOnly = opts.previewOnly || false;
 			const params = resolveParams(opts, "--params", "--json", format);
 
 			try {
+				if (dryRun && previewOnly) throw new Error("Use either --dry-run or --preview-only, not both");
+				if (opts.batch && previewOnly) throw new Error("--preview-only supports one RHE at a time, not --batch");
+				if (opts.batch && !dryRun) {
+					throw new Error(
+						"Live RHE batch emission is disabled. Validate the batch with --dry-run, then preview and emit one RHE at a time.",
+					);
+				}
+				if (!dryRun && !previewOnly && (!opts.yes || !opts.liveSunat)) {
+					throw new Error("Live RHE emission requires both --yes and --live-sunat. Use --preview-only first.");
+				}
 				if (opts.batch) {
 					const filePath = sanitizePath(opts.batch);
 					const csv = readFileSync(filePath, "utf-8");
 					const rows = parseCSV(csv);
-					const creds = getCredentials();
-
-					if (!dryRun) await ensureSOLSession(creds);
 
 					for (const row of rows) {
 						const input = validateRHEInput(row);
-						if (dryRun) {
-							output(format, { json: { dryRun: true, input, status: "would-emit" } });
-						} else {
-							const result = await emitRHE(input);
-							audit({
-								command: "rhe emit",
-								args: input as unknown as Record<string, unknown>,
-								result: "success",
-								details: { ...result },
-							});
-							output(format, { json: { success: true, ...result } });
-						}
+						output(format, { json: { dryRun: true, input, status: "would-emit" } });
 					}
 				} else if (params) {
 					const raw = JSON.parse(params);
@@ -64,14 +65,25 @@ export function createRheCommand(): Command {
 					} else {
 						const creds = getCredentials();
 						await ensureSOLSession(creds);
-						const result = await emitRHE(input);
+						const result = await emitRHE(input, {
+							previewOnly,
+							beforeSubmit: () =>
+								audit({
+									command: "rhe emit",
+									args: input as unknown as Record<string, unknown>,
+									result: "pending",
+									details: { stage: "pre-submit" },
+								}),
+						});
 						audit({
 							command: "rhe emit",
 							args: input as unknown as Record<string, unknown>,
-							result: "success",
-							details: { ...result },
+							result: previewOnly ? "dry-run" : result.status === "submitted-unverified" ? "pending" : "success",
+							details: previewOnly
+								? { stage: "pre-submit" }
+								: { status: result.status === "submitted-unverified" ? "submitted" : "completed" },
 						});
-						output(format, { json: { success: true, ...result } });
+						output(format, { json: { success: previewOnly || result.status === "issued", ...result } });
 					}
 				} else {
 					outputError("Provide --params or --batch. Use 'sunat-cli schema rhe' to see fields.", format);
@@ -104,15 +116,48 @@ export function createRheCommand(): Command {
 }
 
 function validateRHEInput(raw: Record<string, unknown>): RHEInput {
+	const tipoDoc = validateTipoDoc(String(raw.tipoDoc || "SIN DOCUMENTO"));
+	if (tipoDoc !== "SIN DOCUMENTO") {
+		throw new Error(
+			"RHE emit currently supports tipoDoc SIN DOCUMENTO only; RUC/DNI validation needs a separate captured flow",
+		);
+	}
+	const descripcion = rejectControlChars(String(raw.descripcion || "").trim());
+	if (!descripcion) throw new Error("descripcion cannot be empty");
+	if (descripcion.length > 200) throw new Error(`descripcion too long: ${descripcion.length} chars (max 200)`);
+	const fechaEmision = validateRHEFecha(String(raw.fechaEmision || peruToday()));
 	return {
 		empresa: validateEmpresa(String(raw.empresa || "")),
-		tipoDoc: validateTipoDoc(String(raw.tipoDoc || "SIN DOCUMENTO")),
-		descripcion: String(raw.descripcion || ""),
+		tipoDoc,
+		descripcion,
 		monto: validateMonto(Number(raw.monto || raw.monto_pen || 0)),
 		moneda: validateMoneda(String(raw.moneda || "PEN")),
 		medioPago: validateMedioPago(String(raw.medioPago || "TRANSFERENCIA")),
-		fechaEmision: String(raw.fechaEmision || ""),
+		fechaEmision,
 	};
+}
+
+function validateRHEFecha(value: string, now = new Date()): string {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) throw new Error(`Invalid fechaEmision: expected YYYY-MM-DD, got "${value}"`);
+	const date = new Date(`${value}T00:00:00Z`);
+	if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== value) {
+		throw new Error(`Invalid fechaEmision: "${value}" is not a calendar date`);
+	}
+	const currentDay = new Date(`${peruToday(now)}T00:00:00Z`).getTime();
+	const difference = Math.round((currentDay - date.getTime()) / 86_400_000);
+	if (difference < 0) throw new Error("fechaEmision cannot be in the future");
+	if (difference > 2)
+		throw new Error("fechaEmision is outside the observed SUNAT window of today or the previous 2 days");
+	return value;
+}
+
+function peruToday(now = new Date()): string {
+	return new Intl.DateTimeFormat("en-CA", {
+		timeZone: "America/Lima",
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	}).format(now);
 }
 
 function parseCSV(csv: string): Record<string, string>[] {

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -68,7 +68,7 @@ type SchemaName = (typeof AVAILABLE_SCHEMAS)[number];
 // only when the described contract changes, so an agent diffing it does not
 // see churn from unrelated releases. Bump on any field, flag or shape change.
 const SCHEMA_VERSIONS: Record<SchemaName, string> = {
-	rhe: "1.0.0",
+	rhe: "2.0.0",
 	f616: "1.0.0",
 	renta: "1.0.0",
 	buzon: "1.0.0",

--- a/packages/cli/src/schemas/rhe.json
+++ b/packages/cli/src/schemas/rhe.json
@@ -10,9 +10,9 @@
 		},
 		"tipoDoc": {
 			"type": "enum",
-			"values": ["SIN DOCUMENTO", "RUC", "DNI", "CARNET DE EXTRANJERIA", "PASAPORTE", "CED. DIPLOMATICA DE IDENTIDAD"],
+			"values": ["SIN DOCUMENTO"],
 			"default": "SIN DOCUMENTO",
-			"description": "Client document type. Use SIN DOCUMENTO for foreign companies."
+			"description": "Verified recipient path. RUC and DNI require a separate validation transition not present in the captured flow."
 		},
 		"descripcion": {
 			"type": "string",
@@ -31,7 +31,7 @@
 			"type": "enum",
 			"values": ["PEN", "USD"],
 			"default": "PEN",
-			"description": "Currency. PEN for soles, USD for dollars (auto-converts)."
+			"description": "Currency. PEN was present in the captured flow; reconcile USD with --preview-only before live use."
 		},
 		"medioPago": {
 			"type": "enum",
@@ -52,13 +52,15 @@
 			"type": "date",
 			"format": "YYYY-MM-DD",
 			"default": "today",
-			"description": "Emission date. SUNAT allows max 2-3 days retroactive."
+			"description": "Emission date. The observed portal accepts today or the previous 2 days."
 		}
 	},
 	"flags": {
-		"--dry-run": "Preview the RHE without submitting to SUNAT",
+		"--dry-run": "Validate and print the payload without opening SUNAT",
+		"--preview-only": "Fill SUNAT, reconcile the rendered preview, and stop before Emitir Recibo",
+		"--yes --live-sunat": "Required together to invoke the production submission",
 		"--output json": "Machine-readable JSON output",
-		"--batch <file>": "Process multiple RHEs from CSV file"
+		"--batch <file>": "Validate multiple RHEs from CSV with --dry-run; live batches are disabled"
 	},
 	"auth": "Requires SOL session. Run 'sunat-cli login' first.",
 	"portal": "SOL viejo (e-menu.sunat.gob.pe/cl-ti-itmenu/) — NO CAPTCHA"

--- a/packages/cli/src/skills/core.md
+++ b/packages/cli/src/skills/core.md
@@ -4,7 +4,8 @@ SUNAT tax automation via `npx @crafter/sunat-cli` (or `sunat-cli` if globally in
 
 Install: `npm install -g @crafter/sunat-cli`. Runs on Node, no Bun needed.
 
-RHE, F616 and the portal scrapers drive a real browser through
+RHE uses a real browser for SOL bootstrap and final confirmation, with direct
+HTTP form transitions through the server preview. F616 and portal scrapers use
 [agent-browser](https://github.com/vercel-labs/agent-browser), which is a
 separate binary rather than a bundled dependency:
 
@@ -45,41 +46,42 @@ For non-interactive setup, pipe the secret with `sunat-cli keychain set SUNAT_PA
 ### RHE (Recibo por Honorarios)
 
 ```bash
-# Emit single RHE
+# Build and reconcile one RHE draft in SUNAT
 sunat-cli rhe emit --params '{
   "empresa": "Cliente Ejemplo",
   "tipoDoc": "SIN DOCUMENTO",
   "descripcion": "Servicios de desarrollo de software",
   "monto": 6700,
-  "moneda": "USD",
+  "moneda": "PEN",
   "medioPago": "TRANSFERENCIA"
-}'
+}' --preview-only
 
-# Preview without submitting
+# Validate locally without opening SUNAT
 sunat-cli rhe emit --params '...' --dry-run
 
-# Batch from CSV
-sunat-cli rhe emit --batch recibos.csv
+# Reach SUNAT's server preview by direct HTTP and render it for review
+sunat-cli rhe emit --params '...' --preview-only
 
-# List issued RHEs
-sunat-cli rhe list
+# Emit only after visually checking the preview
+sunat-cli rhe emit --params '...' --yes --live-sunat
 
-# Verify registration
-sunat-cli rhe verify --month 2026-03
+# Validate a CSV batch locally
+sunat-cli rhe emit --batch recibos.csv --dry-run
 ```
 
 **RHE fields**: `sunat-cli skills get schemas` for the full field specs.
 
 Key rules:
-- `tipoDoc`: Use `SIN DOCUMENTO` for foreign companies (no RUC/DNI)
-- `moneda`: USD requires explicit `tipoCambio` in beta
+- `tipoDoc`: Only `SIN DOCUMENTO` is verified. RUC/DNI have an additional validation transition that still needs an authorized capture.
+- `moneda`: The captured HAR used PEN. Always reconcile USD with `--preview-only` before live use.
 - `fechaEmision`: the portal refuses anything older than 2 days. Measured, not
   documented by SUNAT: no published resolution sets that limit, but the form
   enforces it with an alert that closes on its own (invisible to snapshots; the
   visible symptom is that the form simply does not advance).
-- `fechaEmision` **is accepted but never written to the form** by `rhe emit`, and
-  still comes back in the result as if it had been. Check before trusting a batch.
-- Auth: SOL viejo portal through headed browser automation. Captcha/session behavior can change, so keep it supervised.
+- `fechaEmision` is sent as `fecemi` in DD/MM/YYYY and reconciled against the rendered server preview.
+- The observed flow is `CONTADO`, non-gratuito, inciso A, no withholding and fully paid at emission.
+- Auth: headed SOL bootstrap; deduction, identity and details go by direct HTTP; final confirmation remains supervised in the browser.
+- Live batches are disabled. Validate CSV with `--dry-run`, then preview and emit each RHE individually.
 
 ### F616 (Monthly Tax Declaration)
 
@@ -206,8 +208,8 @@ form between periods**. Eight periods spanning nine months were filed this way o
 
 **Emit an RHE**:
 1. `sunat-cli login`
-2. `sunat-cli rhe emit --params '{"empresa":"Cliente Ejemplo","tipoDoc":"SIN DOCUMENTO","descripcion":"Servicios de desarrollo de software - Marzo 2026","monto":6700,"moneda":"USD","medioPago":"TRANSFERENCIA","tipoCambio":3.75}' --dry-run`
-3. `sunat-cli rhe verify --month 2026-03`
+2. `sunat-cli rhe emit --params '{"empresa":"Cliente Ejemplo","tipoDoc":"SIN DOCUMENTO","descripcion":"Servicios de desarrollo de software - Agosto 2026","monto":6700,"moneda":"PEN","medioPago":"TRANSFERENCIA"}' --preview-only`
+3. Check the headed browser, then rerun with `--yes --live-sunat`
 
 ## Error Handling
 

--- a/packages/cli/src/skills/endpoints.md
+++ b/packages/cli/src/skills/endpoints.md
@@ -87,6 +87,24 @@ SUNAT publishes a rate for every calendar day, weekends included.
 | `15.1.1.1.1` | Consulta de Valores Pendientes de Pago |
 | `12.1.1.1.4` | Consulta de Declaraciones Juradas y Pagos |
 
+### RHE emission
+
+Menu SOL action `11.5.1.1.2` mints a fresh entry URL. A direct GET of that URL
+needs no imported browser cookies and creates the RHE form session. Every later
+stage posts to `/ol-ti-itreciboelectronico/cpelec001Alias`:
+
+| Stage | `accion` |
+|---|---|
+| Deduction | `RHEDeduccion1` |
+| Identity | `CapturaDatosReciboHonorariosIdentidad` |
+| Details and server preview | `CapturaDatosReciboHonorarios` |
+| Production submission | `GrabaReciboHonorarios` |
+
+The entry URL carries six required query fields: `accion`, `p`, `tenc`, `prg`,
+`fecenv` and `usub`. Treat the whole URL as a secret. Direct HTTP is verified
+through preview for `CONTADO` + `SIN DOCUMENTO`; the final submission remains a
+browser confirmation. The raw HAR is private and excluded from the repository.
+
 ### Reporte Tributario para Terceros
 
 `/ol-ti-itreportetri/reportetri.htm` → tick `#chkAceptar`, then `#btnAceptar`,

--- a/packages/cli/src/skills/schemas.md
+++ b/packages/cli/src/skills/schemas.md
@@ -5,14 +5,18 @@
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | empresa | string(100) | yes | - | Company/person name receiving the service |
-| tipoDoc | enum | no | SIN DOCUMENTO | SIN DOCUMENTO, RUC, DNI, CARNET DE EXTRANJERIA, PASAPORTE, CED. DIPLOMATICA DE IDENTIDAD |
+| tipoDoc | enum | no | SIN DOCUMENTO | Only SIN DOCUMENTO is verified. RUC/DNI require an uncaptured validation transition. |
 | descripcion | string(200) | yes | - | Service description |
-| monto | number | yes | - | Total amount (0.01-1000000). USD auto-converts to PEN |
+| monto | number | yes | - | Total amount (0.01-1000000). The captured flow used PEN; preview USD before live use. |
 | moneda | enum | no | PEN | PEN or USD |
 | medioPago | enum | no | TRANSFERENCIA | DEPOSITO, GIRO, TRANSFERENCIA, ORDEN DE PAGO, TARJETA DEBITO, TARJETA CREDITO, CHEQUE, EFECTIVO |
-| fechaEmision | date | no | today | The portal refuses anything older than 2 days. **Accepted by the CLI but never written to the form**, and returned in the result as if it had been |
+| fechaEmision | date | no | today | YYYY-MM-DD. Written as DD/MM/YYYY. The observed portal accepts today or the previous 2 days. |
 
 Portal: SOL viejo (e-menu.sunat.gob.pe/cl-ti-itmenu/) -- no captcha.
+
+`--dry-run` validates locally. `--preview-only` sends the stateful form endpoint
+through the server draft, renders it in the iframe and stops at the reconciled
+`Emitir Recibo` page. Submission requires `--yes --live-sunat`.
 
 ## F616 Declare Fields
 

--- a/packages/cli/src/workflows/rhe.ts
+++ b/packages/cli/src/workflows/rhe.ts
@@ -1,6 +1,5 @@
-import { SOL_MENU_URL } from "../browser/auth.ts";
+import { type CdpSession, connect } from "../browser/cdp.ts";
 import * as browser from "../browser/client.ts";
-import { today } from "../utils/dates.ts";
 import type { MedioPago, TipoDocumento } from "../validation/input.ts";
 
 export interface RHEInput {
@@ -13,178 +12,247 @@ export interface RHEInput {
 	fechaEmision: string;
 }
 
-export interface RHEResult {
+export interface RHEPreview {
+	status: "ready-to-emit";
 	empresa: string;
-	montoPEN: number;
-	retencion8Pct: number;
-	netoRecibido: number;
+	monto: number;
+	moneda: "PEN" | "USD";
+	medioPago: MedioPago;
+	retencion: number;
+	neto: number;
 	fechaEmision: string;
 }
 
-const MEDIO_PAGO_SUNAT: Record<string, string> = {
-	DEPOSITO: "Depósito en Cuenta",
-	GIRO: "Giro",
-	TRANSFERENCIA: "Transferencia de Fondos",
-	"ORDEN DE PAGO": "Orden de Pago",
-	"TARJETA DEBITO": "Tarjeta de Débito",
-	"TARJETA CREDITO": "Tarjeta de Crédito emitida en el país por una empresa del Sistema Financiero",
-	CHEQUE: "Cheques con cláusula: no negociables - intransferibles - no a la orden o similar",
-	EFECTIVO: "Efectivo - por operaciones donde no existe obligación de utilizar Medios de Pago",
+export interface RHEResult extends Omit<RHEPreview, "status"> {
+	status: "issued" | "submitted-unverified";
+	serie?: string;
+	numero?: string;
+}
+
+const DOCUMENTO_SUNAT: Record<TipoDocumento, string> = {
+	"SIN DOCUMENTO": "-",
+	RUC: "6",
+	DNI: "1",
+	"CARNET DE EXTRANJERIA": "4",
+	PASAPORTE: "7",
+	"CED. DIPLOMATICA DE IDENTIDAD": "A",
 };
 
-export async function emitRHE(input: RHEInput): Promise<RHEResult> {
-	// Navigate to RHE form
+const MEDIO_PAGO_SUNAT: Record<MedioPago, string> = {
+	DEPOSITO: "001",
+	GIRO: "002",
+	TRANSFERENCIA: "003",
+	"ORDEN DE PAGO": "004",
+	"TARJETA DEBITO": "005",
+	"TARJETA CREDITO": "006",
+	CHEQUE: "007",
+	EFECTIVO: "008",
+};
+
+export function toRHEPortalDate(iso: string): string {
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+	if (!match) throw new Error(`Invalid fechaEmision: expected YYYY-MM-DD, got "${iso}"`);
+	return `${match[3]}/${match[2]}/${match[1]}`;
+}
+
+export function toRHEPreviewDate(iso: string): string {
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+	if (!match) throw new Error(`Invalid fechaEmision: expected YYYY-MM-DD, got "${iso}"`);
+	const months = [
+		"Enero",
+		"Febrero",
+		"Marzo",
+		"Abril",
+		"Mayo",
+		"Junio",
+		"Julio",
+		"Agosto",
+		"Septiembre",
+		"Octubre",
+		"Noviembre",
+		"Diciembre",
+	];
+	return `${Number(match[3])} de ${months[Number(match[2]) - 1]} de ${match[1]}`;
+}
+
+export function buildRHEIdentityParams(input: RHEInput): URLSearchParams {
+	return new URLSearchParams({
+		accion: "CapturaDatosReciboHonorariosIdentidad",
+		formaPago: "CONTADO",
+		tipdoc: DOCUMENTO_SUNAT[input.tipoDoc],
+		nombrecliente: input.empresa,
+		ubigeoUsuario: "-",
+		direccionUsuario: "-",
+		txtUbi_Codigo: " ",
+		txtUbi_departamento: " ",
+		txtUbi_provincia: " ",
+		txtUbi_distrito: " ",
+	});
+}
+
+export function buildRHEDetailsParams(input: RHEInput): URLSearchParams {
+	const amount = input.monto.toFixed(2);
+	return new URLSearchParams({
+		accion: "CapturaDatosReciboHonorarios",
+		total2: new Intl.NumberFormat("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(input.monto),
+		retencion2: "0.00",
+		indrenta: "A",
+		gratuito: "0",
+		montoNetoPendientePago: "",
+		numCuotasRhe: "",
+		indgratuito: "0",
+		motivo: input.descripcion,
+		observacion: "-",
+		fecemi: toRHEPortalDate(input.fechaEmision),
+		indrenta1: "A",
+		indretencion: "00",
+		indretregimen: "0",
+		indpago: "01",
+		mediopago: MEDIO_PAGO_SUNAT[input.medioPago],
+		indpagorecibo: "0",
+		moneda: input.moneda,
+		cantidad: amount,
+		mto_aporte_snp: "0.00",
+		mto_aporte_aporteafp: "0.00",
+		mto_aporte_comisionafp: "0.00",
+		mto_aporte_seguroafp: "0.00",
+		indexCuota: "",
+		montoCuota: "0.0",
+	});
+}
+
+export function parsePortalAmount(value: string): number {
+	const cleaned = value.replace(/[^\d,.-]/g, "");
+	if (!cleaned) return Number.NaN;
+	const lastComma = cleaned.lastIndexOf(",");
+	const lastDot = cleaned.lastIndexOf(".");
+	const decimalIndex = Math.max(lastComma, lastDot);
+	const decimalDigits = decimalIndex >= 0 ? cleaned.length - decimalIndex - 1 : 0;
+	const normalized =
+		decimalIndex >= 0 && decimalDigits > 0 && decimalDigits <= 2
+			? `${cleaned.slice(0, decimalIndex).replace(/[.,]/g, "")}.${cleaned.slice(decimalIndex + 1)}`
+			: cleaned.replace(/[.,]/g, "");
+	return Number(normalized);
+}
+
+export function extractRHEConfirmation(text: string): { serie?: string; numero?: string } {
+	const match = text.match(/\b(E\d{3})\s*[-–]\s*(\d{1,20})\b/i);
+	if (!match) return {};
+	return { serie: match[1].toUpperCase(), numero: match[2] };
+}
+
+export async function emitRHE(
+	input: RHEInput,
+	opts: { previewOnly?: boolean; beforeSubmit?: () => void | Promise<void> } = {},
+): Promise<RHEPreview | RHEResult> {
+	if (input.tipoDoc !== "SIN DOCUMENTO") {
+		throw new Error(
+			"RHE emit currently supports tipoDoc SIN DOCUMENTO only; document validation was not present in the captured flow",
+		);
+	}
+
 	await browser.evalJS(
 		"ejecuta('MenuInternet.htm?action=iconExecute&code=11.5.1.1.2',false,'Emisión de Recibo por Honorarios Electrónico','#nivel1_11','11.5.1.1.2')",
 	);
-	await browser.sleep(4000);
-
-	// === STEP 1: Pre-question (Deduccion adicional) ===
-	let snap = await browser.snapshot({ interactive: true });
-	assertContains(snap, "Iframe", "RHE form did not load");
-	const btn1 = findRef(snap, "Continuar", "button");
-	await browser.click(btn1);
 	await browser.sleep(3000);
 
-	// === STEP 2: Client info ===
-	snap = await browser.snapshot({ interactive: true });
-	const comboRef = findRef(snap, "combobox", null);
-	if (input.tipoDoc !== "RUC") {
-		await browser.select(comboRef, input.tipoDoc);
-		await browser.sleep(1500);
-		snap = await browser.snapshot({ interactive: true });
-	}
+	await onRHEPage(
+		`typeof opcGrabar==='function'&&!!document.querySelector('input[name="inddeduccion"]')`,
+		async (session) => {
+			const identityParams = buildRHEIdentityParams(input).toString();
+			const detailsParams = buildRHEDetailsParams(input).toString();
+			await evaluate(
+				session,
+				`(async function(){var endpoint='/ol-ti-itreciboelectronico/cpelec001Alias';var post=async function(stage,body,expected){var response=await fetch(endpoint,{method:'POST',credentials:'include',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:body});var html=await response.text();if(response.status!==200||!expected.test(html))throw new Error('RHE_HTTP_STAGE:'+stage+':unexpected-response');return html};var first=new URLSearchParams(new FormData(document.forms[0]));first.set('accion','RHEDeduccion1');first.set('deduccion','0');first.set('inddeduccion','0');await post('deduction',first,/name=["']tipdoc/i);await post('identity',new URLSearchParams(${JSON.stringify(identityParams)}),/name=["']motivo/i);var preview=await post('details',new URLSearchParams(${JSON.stringify(detailsParams)}),/Emitir Recibo/i);document.open();document.write(preview);document.close();return 'ready-to-emit'})()`,
+			);
+		},
+	);
+	await browser.sleep(1000);
 
-	// When SIN DOCUMENTO: nombre textbox becomes enabled, numero becomes disabled
-	// Find the enabled (non-disabled) textbox after the combobox
-	const nombreRef = findFirstEnabled(snap, "textbox");
-	await browser.fill(nombreRef, input.empresa);
+	const preview = await onRHEPage(
+		`!![...document.querySelectorAll('input[name="wacepta"]')].find(function(el){return /Emitir Recibo/i.test(el.value)})`,
+		async (session) => {
+			const currencyLabel = input.moneda === "USD" ? "DÓLAR DE NORTE AMÉRICA" : "SOL";
+			const previewDate = toRHEPreviewDate(input.fechaEmision);
+			const checksRaw = await evaluate(
+				session,
+				`(function(){var norm=function(value){return String(value||'').normalize('NFD').replace(/[\u0300-\u036f]/g,'').replace(/\\s+/g,' ').trim().toLowerCase()};var raw=document.body&&document.body.innerText||'';var text=norm(raw);var amount=function(label){var cell=[...document.querySelectorAll('td')].find(function(td){return label.test(norm(td.textContent))});return cell&&cell.nextElementSibling&&cell.nextElementSibling.nextElementSibling?cell.nextElementSibling.nextElementSibling.textContent.trim():''};return JSON.stringify({empresa:text.includes(norm(${JSON.stringify(input.empresa)})),descripcion:text.includes(norm(${JSON.stringify(input.descripcion)})),moneda:text.includes(norm(${JSON.stringify(currencyLabel)})),fecha:text.includes(norm(${JSON.stringify(previewDate)})),total:amount(/^total por honorarios$/),retencion:amount(/^retencion .* ir$/),neto:amount(/^total neto recibido$/)});})()`,
+			);
+			const checks = JSON.parse(String(checksRaw)) as {
+				empresa: boolean;
+				descripcion: boolean;
+				moneda: boolean;
+				fecha: boolean;
+				total: string;
+				retencion: string;
+				neto: string;
+			};
+			if (!checks.empresa || !checks.descripcion || !checks.moneda || !checks.fecha) {
+				throw new Error(
+					"RHE preview could not be reconciled with the requested client, description, date, and currency",
+				);
+			}
+			const total = parsePortalAmount(checks.total);
+			if (!Number.isFinite(total) || Math.abs(total - input.monto) > 0.01) {
+				throw new Error("RHE preview total does not match the requested amount");
+			}
+			const parsedRetencion = parsePortalAmount(checks.retencion);
+			const retencion = Number.isFinite(parsedRetencion) ? parsedRetencion : 0;
+			const parsedNeto = parsePortalAmount(checks.neto);
+			const neto = Number.isFinite(parsedNeto) ? parsedNeto : total - retencion;
+			return {
+				status: "ready-to-emit" as const,
+				empresa: input.empresa,
+				monto: input.monto,
+				moneda: input.moneda,
+				medioPago: input.medioPago,
+				retencion,
+				neto,
+				fechaEmision: input.fechaEmision,
+			};
+		},
+	);
 
-	const btn2 = findRef(snap, "Continuar", "button");
-	await browser.click(btn2);
+	if (opts.previewOnly) return preview;
+	await opts.beforeSubmit?.();
+
+	await onRHEPage(
+		`!![...document.querySelectorAll('input[name="wacepta"]')].find(function(el){return /Emitir Recibo/i.test(el.value)})`,
+		async (session) => {
+			await evaluate(
+				session,
+				`[...document.querySelectorAll('input[name="wacepta"]')].find(function(el){return /Emitir Recibo/i.test(el.value)}).click();'ok'`,
+			);
+		},
+	);
 	await browser.sleep(3000);
 
-	// === STEP 3: Service details + amount ===
-	snap = await browser.snapshot({ interactive: true });
-
-	// Descripcion — first enabled textbox in iframe
-	const allTextboxes = findAllEnabled(snap, "textbox");
-	if (allTextboxes.length < 1) throw new Error("No textboxes found in step 3");
-
-	// allTextboxes[0] = descripcion, [1] = observacion(opt), [2] = fecha, [3] = monto
-	await browser.fill(allTextboxes[0], input.descripcion);
-
-	// Medio de pago dropdown — find combobox containing "Medio de Pago" or first unset combobox
-	const medioPagoRef = findRef(snap, "Seleccione Medio de Pago", "combobox") || findRef(snap, "combobox", null);
-	const medioPagoValue = MEDIO_PAGO_SUNAT[input.medioPago] || input.medioPago;
-	await browser.select(medioPagoRef, medioPagoValue);
-
-	// Moneda — only change if USD
-	if (input.moneda === "USD") {
-		const monedaRef = findRef(snap, "SOL", "combobox");
-		await browser.select(monedaRef, "DÓLAR DE NORTE AMÉRICA");
-		await browser.sleep(500);
-	}
-
-	// Monto — find the textbox with "0.0" value (the enabled one near "Monto Total")
-	const montoRef = findRefByValue(snap, "0.0", "textbox");
-	await browser.fill(montoRef, String(input.monto));
-
-	// Click Continuar → preview
-	const btn3 = findRef(snap, "Continuar", "button");
-	await browser.click(btn3);
-	await browser.sleep(4000);
-
-	// === STEP 4: Preview & submit ===
-	snap = await browser.snapshot({ interactive: true });
-	// Look for Emitir, Aceptar, or Continuar button
-	const submitBtn =
-		findRefSafe(snap, "Emitir", "button") ||
-		findRefSafe(snap, "Aceptar", "button") ||
-		findRef(snap, "Continuar", "button");
-	await browser.click(submitBtn);
-	await browser.sleep(4000);
-
-	// Handle potential confirmation dialog
-	try {
-		snap = await browser.snapshot({ interactive: true });
-		const confirmBtn =
-			findRefSafe(snap, "Aceptar", "button") || findRefSafe(snap, "OK", "button") || findRefSafe(snap, "Sí", "button");
-		if (confirmBtn) {
-			await browser.click(confirmBtn);
-			await browser.sleep(3000);
-		}
-	} catch {}
-
-	// Clean up and return to dashboard
-	await browser.clearBeforeUnload();
-	await browser.open(SOL_MENU_URL, {
-		headed: true,
+	const confirmation = await onRHEPage(`!!document.querySelector('input[name="wpagos"]')`, async (session) => {
+		const raw = await evaluate(
+			session,
+			`(function(){var text=document.body&&document.body.innerText||'';var match=text.match(/\\b(E\\d{3})\\s*[-–]\\s*(\\d{1,20})\\b/i);return JSON.stringify(match?{serie:match[1].toUpperCase(),numero:match[2]}:{});})()`,
+		);
+		return JSON.parse(String(raw)) as { serie?: string; numero?: string };
 	});
-	await browser.sleep(2000);
 
 	return {
-		empresa: input.empresa,
-		montoPEN: input.monto,
-		retencion8Pct: Math.round(input.monto * 0.08 * 100) / 100,
-		netoRecibido: Math.round(input.monto * 0.92 * 100) / 100,
-		fechaEmision: input.fechaEmision || today(),
+		...preview,
+		status: confirmation.serie && confirmation.numero ? "issued" : "submitted-unverified",
+		...confirmation,
 	};
 }
 
-function assertContains(snap: string, text: string, msg: string): void {
-	if (!snap.includes(text)) throw new Error(msg);
-}
-
-function findRef(snap: string, text: string, type: string | null): string {
-	const ref = findRefSafe(snap, text, type);
-	if (!ref) throw new Error(`Element not found: ${type || "any"} containing "${text}"`);
-	return ref;
-}
-
-function findRefSafe(snap: string, text: string, type: string | null): string | null {
-	for (const line of snap.split("\n")) {
-		const matchesType = !type || line.includes(type);
-		const matchesText = line.toLowerCase().includes(text.toLowerCase());
-		const notDisabled = !line.includes("disabled");
-		if (matchesType && matchesText && notDisabled) {
-			const m = line.match(/ref=(e\d+)/);
-			if (m) return `@${m[1]}`;
-		}
+async function onRHEPage<T>(probe: string, run: (session: CdpSession) => Promise<T>): Promise<T> {
+	const session = await connect({ pageUrl: "MenuInternet", origin: "ww1.sunat.gob.pe", probe });
+	try {
+		return await run(session);
+	} finally {
+		session.close();
 	}
-	return null;
 }
 
-function findFirstEnabled(snap: string, type: string): string {
-	for (const line of snap.split("\n")) {
-		if (line.includes("Iframe")) continue;
-		if (line.includes(type) && !line.includes("disabled") && line.includes("ref=")) {
-			const m = line.match(/ref=(e\d+)/);
-			if (m) return `@${m[1]}`;
-		}
-	}
-	throw new Error(`No enabled ${type} found`);
-}
-
-function findAllEnabled(snap: string, type: string): string[] {
-	const refs: string[] = [];
-	let inIframe = false;
-	for (const line of snap.split("\n")) {
-		if (line.includes("Iframe")) inIframe = true;
-		if (inIframe && line.includes(type) && !line.includes("disabled")) {
-			const m = line.match(/ref=(e\d+)/);
-			if (m) refs.push(`@${m[1]}`);
-		}
-	}
-	return refs;
-}
-
-function findRefByValue(snap: string, value: string, type: string): string {
-	for (const line of snap.split("\n")) {
-		if (line.includes(type) && !line.includes("disabled") && line.includes(`: ${value}`)) {
-			const m = line.match(/ref=(e\d+)/);
-			if (m) return `@${m[1]}`;
-		}
-	}
-	throw new Error(`No ${type} with value "${value}" found`);
+async function evaluate(session: CdpSession, expression: string): Promise<unknown> {
+	const result = await session.evalIn(expression);
+	if (result.err) throw new Error(`RHE portal evaluation failed: ${result.err}`);
+	return result.val;
 }

--- a/packages/cli/tests/e2e/params-flag.test.ts
+++ b/packages/cli/tests/e2e/params-flag.test.ts
@@ -124,3 +124,33 @@ describe("deprecation notice shape", () => {
 		expect(stderr.match(/--json is deprecated/g)).toHaveLength(1);
 	});
 });
+
+describe("RHE live boundary", () => {
+	test("requires both live acknowledgements before opening SUNAT", async () => {
+		const { stderr } = await run(["rhe", "emit", "--params", RHE_PAYLOAD]);
+		expect(stderr).toContain("requires both --yes and --live-sunat");
+	});
+
+	test("documents the portal preview and live acknowledgements", async () => {
+		const { stdout } = await run(["rhe", "emit", "--help"]);
+		expect(stdout).toContain("--preview-only");
+		expect(stdout).toContain("--yes");
+		expect(stdout).toContain("--live-sunat");
+	});
+
+	test("publishes the gated RHE contract as schema v2", async () => {
+		const { stdout } = await run(["schema", "rhe"]);
+		expect(JSON.parse(stdout).version).toBe("2.0.0");
+	});
+
+	test("rejects unsupported document-backed recipients during dry-run", async () => {
+		const payload = JSON.stringify({ ...JSON.parse(RHE_PAYLOAD), tipoDoc: "RUC" });
+		const { stderr } = await run(["rhe", "emit", "--params", payload, "--dry-run"]);
+		expect(stderr).toContain("supports tipoDoc SIN DOCUMENTO only");
+	});
+
+	test("disables live batch emission before reading the CSV", async () => {
+		const { stderr } = await run(["rhe", "emit", "--batch", "missing.csv", "--yes", "--live-sunat"]);
+		expect(stderr).toContain("Live RHE batch emission is disabled");
+	});
+});

--- a/packages/cli/tests/unit/buzon-portal.test.ts
+++ b/packages/cli/tests/unit/buzon-portal.test.ts
@@ -15,7 +15,7 @@ describe("Buzón portal boundary", () => {
 		expect(AUTH_SOURCE).toContain("MenuInternet.htm?pestana=*&agrupacion=*");
 		expect(PORTAL_SOURCE).toContain("SOL_MENU_URL");
 		expect(F616_SOURCE).toContain("SOL_MENU_URL");
-		expect(RHE_SOURCE).toContain("SOL_MENU_URL");
+		expect(RHE_SOURCE).toContain('connect({ pageUrl: "MenuInternet", origin: "ww1.sunat.gob.pe", probe })');
 		expect(F616_SOURCE).not.toContain('browser.open("https://e-menu.sunat.gob.pe/cl-ti-itmenu/MenuInternet.htm"');
 		expect(route).toBeGreaterThan(-1);
 		expect(click).toBeGreaterThan(route);

--- a/packages/cli/tests/unit/rhe.test.ts
+++ b/packages/cli/tests/unit/rhe.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildRHEDetailsParams,
+	buildRHEIdentityParams,
+	extractRHEConfirmation,
+	parsePortalAmount,
+	type RHEInput,
+	toRHEPortalDate,
+	toRHEPreviewDate,
+} from "../../src/workflows/rhe.ts";
+
+const input: RHEInput = {
+	empresa: "CLIENTE RECON",
+	tipoDoc: "SIN DOCUMENTO",
+	descripcion: "SERVICIO RECON",
+	monto: 22399.1,
+	moneda: "PEN",
+	medioPago: "TRANSFERENCIA",
+	fechaEmision: "2026-08-26",
+};
+
+describe("RHE portal contract", () => {
+	test("converts the CLI date into the field format observed in the portal", () => {
+		expect(toRHEPortalDate("2026-08-26")).toBe("26/08/2026");
+		expect(toRHEPreviewDate("2026-08-26")).toBe("26 de Agosto de 2026");
+		expect(() => toRHEPortalDate("26/08/2026")).toThrow("expected YYYY-MM-DD");
+	});
+
+	test("builds the direct identity transition observed in the portal", () => {
+		const params = buildRHEIdentityParams(input);
+		expect(params.get("accion")).toBe("CapturaDatosReciboHonorariosIdentidad");
+		expect(params.get("formaPago")).toBe("CONTADO");
+		expect(params.get("tipdoc")).toBe("-");
+		expect(params.get("nombrecliente")).toBe("CLIENTE RECON");
+	});
+
+	test("builds the direct details transition without the final issue action", () => {
+		const params = buildRHEDetailsParams(input);
+		expect(params.get("accion")).toBe("CapturaDatosReciboHonorarios");
+		expect(params.get("total2")).toBe("22,399.10");
+		expect(params.get("cantidad")).toBe("22399.10");
+		expect(params.get("fecemi")).toBe("26/08/2026");
+		expect(params.get("mediopago")).toBe("003");
+		expect(params.toString()).not.toContain("GrabaReciboHonorarios");
+	});
+
+	test("parses SUNAT amounts without assuming one thousands separator", () => {
+		expect(parsePortalAmount("S/ 1,234.56")).toBe(1234.56);
+		expect(parsePortalAmount("1.234,56")).toBe(1234.56);
+		expect(parsePortalAmount("6700.00")).toBe(6700);
+		expect(Number.isNaN(parsePortalAmount(""))).toBe(true);
+	});
+
+	test("extracts the issued RHE identifier from the confirmation page", () => {
+		expect(extractRHEConfirmation("Recibo por Honorarios Electrónico E001 - 123456")).toEqual({
+			serie: "E001",
+			numero: "123456",
+		});
+		expect(extractRHEConfirmation("Emitido sin identificador visible")).toEqual({});
+	});
+});

--- a/packages/website/src/lib/content.ts
+++ b/packages/website/src/lib/content.ts
@@ -1,6 +1,6 @@
 import type { Locale } from "./i18n";
 
-export const VERSION = "0.11.2";
+export const VERSION = "0.14.0";
 
 /**
  * Copy lives per locale rather than as a key/value dictionary with one canonical
@@ -35,11 +35,21 @@ export type Content = {
 		roadmap: string;
 		principles: string;
 	};
-	a11y: { skip: string; sections: string; theme: string; language: string; home: string };
+	a11y: {
+		skip: string;
+		sections: string;
+		theme: string;
+		language: string;
+		home: string;
+	};
 	theme: { light: string; system: string; dark: string };
 	hero: { lede: string; cta: string };
 	stats: Stat[];
-	capabilities: { heading: string; count: (n: number) => string; items: Capability[] };
+	capabilities: {
+		heading: string;
+		count: (n: number) => string;
+		items: Capability[];
+	};
 	architecture: {
 		heading: string;
 		prose: string[];
@@ -82,13 +92,13 @@ const es: Content = {
 	},
 	theme: { light: "Claro", system: "Sistema", dark: "Oscuro" },
 	hero: {
-		lede: "SUNAT expone diez superficies distintas: SOAP con XML firmado, REST con OAuth, una cola de tickets, una carga reanudable, un buzón legacy y un formulario que en realidad es una API JSON. Esto las envuelve todas en un binario que un agente puede manejar.",
+		lede: "SUNAT expone diez superficies distintas: SOAP con XML firmado, REST con OAuth, una cola de tickets, una carga reanudable, un buzón legacy, una API JSON y una sesión de formularios HTTP. Esto las envuelve en un binario que un agente puede manejar bajo supervisión.",
 		cta: "Ver qué cubre",
 	},
 	stats: [
 		{ value: "10", label: "Superficies", detail: "un solo binario" },
-		{ value: "500", label: "Tests", detail: "en verde" },
-		{ value: "0", label: "CAPTCHAs", detail: "un login y después headless" },
+		{ value: "500+", label: "Tests", detail: "en verde" },
+		{ value: "2", label: "Modos", detail: "headless y supervisado" },
 	],
 	capabilities: {
 		heading: "Qué cubre",
@@ -121,8 +131,8 @@ const es: Content = {
 			{
 				title: "Rentas de cuarta",
 				scope: "RHE y F616",
-				desc: "Login en el navegador sin CAPTCHA. Los recibos se emiten en lote y el F616 mensual se lee headless desde la API que hay detrás del formulario.",
-				code: '$ sunat-cli f616 declare \\\n    --json \'{"periodo":"2026-03"}\'',
+				desc: "En RHE, el navegador obtiene la entrada SOL, HTTP llega hasta el borrador y la confirmación legal queda visible y bloqueada. F616 conserva su lectura headless por API.",
+				code: '$ sunat-cli rhe emit \\\n    --params \'{"empresa":"Cliente","descripcion":"Servicio","monto":100}\' --preview-only',
 			},
 			{
 				title: "Consultas",
@@ -151,26 +161,26 @@ const es: Content = {
 		],
 	},
 	architecture: {
-		heading: "Headless después de un solo login",
+		heading: "Endpoints primero, navegador en el borde",
 		prose: [
 			"La página del F616 parece un formulario. Es una aplicación de una sola página hablando con una API JSON, y los campos del formulario son la forma menos confiable de llegar ahí.",
-			"Entonces la CLI abre el navegador una vez, captura el token de sesión y lo cierra. Todas las lecturas posteriores van directo a la API que el formulario estaba llamando. Sin CAPTCHA, sin DOM que pelear, sin un proceso de navegador abierto.",
+			"RHE es distinto: Menu SOL genera una entrada efímera y el backend responde HTML. La CLI usa HTTP para deducción, identidad y detalles, vuelve a renderizar el borrador y reserva el DOM para la confirmación legal final.",
 		],
 		steps: [
 			{
 				n: "01",
-				title: "Capturar",
-				desc: "Abre el navegador una vez, inicia sesión, toma el token y lo cierra.",
+				title: "Bootstrap",
+				desc: "Abre SOL y obtiene la entrada o token que la superficie oficial exige.",
 			},
 			{
 				n: "02",
-				title: "Leer headless",
-				desc: "Consulta la API de la declaración directamente con el token en caché, sin navegador corriendo.",
+				title: "HTTP directo",
+				desc: "Llama la API o sesión de formularios y valida la respuesta real del servidor.",
 			},
 			{
 				n: "03",
-				title: "Recapturar al vencer",
-				desc: "Cuando el token expira, captura de nuevo. Todo lo que pasa entre esos dos momentos es headless.",
+				title: "Confirmar",
+				desc: "Para RHE, renderiza el borrador y mantiene la acción legal final bajo control humano.",
 			},
 		],
 	},
@@ -178,7 +188,12 @@ const es: Content = {
 		heading: "Hasta dónde llega cada superficie",
 		shipped: (n, total) => `${n} de ${total} en producción y verificadas`,
 		note: "Los porcentajes son un juicio sobre cuánto de cada superficie está envuelto y disponible para un agente. El lector de metadata del Buzón SOL fue verificado con una cuenta propia en producción. Los envíos tributarios siguen en beta.",
-		th: { surface: "Superficie", wrapped: "Cubierto", pct: "%", state: "Estado" },
+		th: {
+			surface: "Superficie",
+			wrapped: "Cubierto",
+			pct: "%",
+			state: "Estado",
+		},
 		caption: "Cobertura por superficie de SUNAT, con avance y estado",
 		states: {
 			shipped: "listo",
@@ -195,9 +210,9 @@ const es: Content = {
 			},
 			{
 				domain: "RHE y F616",
-				detail: "Personas naturales",
-				pct: 95,
-				state: "shipped",
+				detail: "RHE hasta borrador; F616 lectura API",
+				pct: 85,
+				state: "partial",
 			},
 			{
 				domain: "Buzón SOL",
@@ -255,7 +270,9 @@ const es: Content = {
 		cols: [
 			{
 				when: "Ahora",
-				items: [{ n: 10, t: "Baja con intent token y su barrera de seguridad" }],
+				items: [
+					{ n: 10, t: "Baja con intent token y su barrera de seguridad" },
+				],
 			},
 			{
 				when: "Después",
@@ -270,7 +287,10 @@ const es: Content = {
 				items: [
 					{ n: 13, t: "Driver facturador, wrapper de Java contenido" },
 					{ n: 14, t: "Reportes complementarios de SIRE" },
-					{ n: 15, t: "Índice sqlite para consultas de padrón sub-milisegundo" },
+					{
+						n: 15,
+						t: "Índice sqlite para consultas de padrón sub-milisegundo",
+					},
 					{ n: 16, t: "Jobs de humo en CI con navegador real" },
 					{ n: 17, t: "Reanudar una carga TUS parcial" },
 				],
@@ -294,7 +314,7 @@ const es: Content = {
 			},
 			{
 				rule: "Toda mutación se previsualiza",
-				why: "--dry-run devuelve la misma forma que la llamada real, con un hash, así se puede comparar antes de confirmar.",
+				why: "En RHE, --dry-run valida localmente y --preview-only reconcilia el borrador real de SUNAT antes de habilitar la emisión.",
 			},
 			{
 				rule: "JSON cuando stdout no es una terminal",
@@ -345,13 +365,13 @@ const en: Content = {
 	},
 	theme: { light: "Light", system: "System", dark: "Dark" },
 	hero: {
-		lede: "Peru's tax authority exposes ten different surfaces: SOAP with signed XML, REST with OAuth, a ticket queue, a resumable upload, a legacy inbox, and a form that is really a JSON API. This wraps all of them in one binary an agent can drive.",
+		lede: "Peru's tax authority exposes ten different surfaces: SOAP with signed XML, REST with OAuth, a ticket queue, a resumable upload, a legacy inbox, a JSON API, and a stateful HTTP form session. This wraps them in one supervised agent-facing binary.",
 		cta: "See what it covers",
 	},
 	stats: [
 		{ value: "10", label: "Surfaces", detail: "one binary" },
-		{ value: "500", label: "Tests", detail: "green" },
-		{ value: "0", label: "CAPTCHAs", detail: "one login, then headless" },
+		{ value: "500+", label: "Tests", detail: "green" },
+		{ value: "2", label: "Modes", detail: "headless and supervised" },
 	],
 	capabilities: {
 		heading: "What it covers",
@@ -384,8 +404,8 @@ const en: Content = {
 			{
 				title: "Independent worker filings",
 				scope: "RHE and F616",
-				desc: "Browser login without a CAPTCHA. Receipts issue in batch; the monthly F616 reads headless from the declaration API behind the form.",
-				code: '$ sunat-cli f616 declare \\\n    --json \'{"periodo":"2026-03"}\'',
+				desc: "For RHE, the browser obtains the SOL entry, HTTP reaches the draft, and the legal confirmation stays visible and gated. F616 keeps its headless API read path.",
+				code: '$ sunat-cli rhe emit \\\n    --params \'{"empresa":"Client","descripcion":"Service","monto":100}\' --preview-only',
 			},
 			{
 				title: "Lookups",
@@ -414,26 +434,26 @@ const en: Content = {
 		],
 	},
 	architecture: {
-		heading: "Headless after one login",
+		heading: "Endpoints first, browser at the boundary",
 		prose: [
 			"The F616 declaration page looks like a form. It is a single-page app talking to a JSON API, and the form fields are the least reliable way to reach it.",
-			"So the CLI opens a browser once, captures the session token, and closes it. Every read after that goes straight to the API the form was calling. No CAPTCHA, no DOM to fight, no browser process left running.",
+			"RHE is different: Menu SOL mints an ephemeral entry and the backend returns HTML. The CLI uses HTTP for deduction, identity, and details, renders the draft again, and reserves DOM automation for the final legal confirmation.",
 		],
 		steps: [
 			{
 				n: "01",
-				title: "Capture",
-				desc: "Open the browser once, log in, take the session token, close it.",
+				title: "Bootstrap",
+				desc: "Open SOL and obtain the entry or token required by the official surface.",
 			},
 			{
 				n: "02",
-				title: "Read headless",
-				desc: "Query the declaration API directly with the cached token, with no browser running.",
+				title: "Direct HTTP",
+				desc: "Call the API or form session and validate the server's real response.",
 			},
 			{
 				n: "03",
-				title: "Recapture on expiry",
-				desc: "When the token ages out, capture again. Everything between those two moments stays headless.",
+				title: "Confirm",
+				desc: "For RHE, render the draft and keep the final legal action under human control.",
 			},
 		],
 	},
@@ -458,9 +478,9 @@ const en: Content = {
 			},
 			{
 				domain: "RHE and F616",
-				detail: "Personas naturales",
-				pct: 95,
-				state: "shipped",
+				detail: "RHE through draft; F616 API reads",
+				pct: 85,
+				state: "partial",
 			},
 			{
 				domain: "Buzón SOL",
@@ -557,7 +577,7 @@ const en: Content = {
 			},
 			{
 				rule: "Every mutation previews first",
-				why: "--dry-run returns the same shape as the real call, with a hash, so a caller can diff before committing.",
+				why: "For RHE, --dry-run validates locally and --preview-only reconciles SUNAT's real draft before issuance is enabled.",
 			},
 			{
 				rule: "JSON when stdout is not a terminal",
@@ -613,7 +633,7 @@ export type LegalContent = {
 
 const legalEs: LegalContent = {
 	title: "Marco legal",
-	updated: "Última actualización: 25 de marzo de 2026",
+	updated: "Última actualización: 26 de agosto de 2026",
 	sections: [
 		{
 			heading: "Sobre esta herramienta",
@@ -630,7 +650,7 @@ const legalEs: LegalContent = {
 				"La exactitud de las declaraciones tributarias enviadas con esta herramienta",
 				"El cumplimiento de los plazos y obligaciones tributarias ante SUNAT",
 				"El resguardo de su clave SOL",
-				"Revisar toda operación con --dry-run antes de ejecutarla",
+				"Revisar toda operación con --dry-run y, para RHE, con --preview-only antes de emitir",
 			],
 		},
 		{
@@ -664,7 +684,7 @@ const legalEs: LegalContent = {
 				"El portal de Operaciones en Línea de SUNAT no prohíbe explícitamente el acceso automatizado por parte de usuarios autenticados. Sin embargo:",
 			],
 			list: [
-				"Esta herramienta usa Chrome con interfaz visible, no headless, para no chocar con la detección de bots de SUNAT",
+				"Esta herramienta usa Chrome visible cuando SUNAT exige autenticación o confirmación interactiva y HTTP directo para los tramos verificados",
 				"Las operaciones incluyen demoras realistas entre envíos de formularios",
 				"No se intenta eludir ningún límite de tasa",
 				"La herramienta respeta el vencimiento de sesión y se reautentica correctamente",
@@ -679,7 +699,9 @@ const legalEs: LegalContent = {
 		},
 		{
 			heading: "Licencia de código abierto",
-			paras: ["sunat-cli se publica bajo la licencia MIT. Código fuente: github.com/crafter-research/sunat-cli"],
+			paras: [
+				"sunat-cli se publica bajo la licencia MIT. Código fuente: github.com/crafter-research/sunat-cli",
+			],
 		},
 	],
 	contact: {
@@ -692,7 +714,7 @@ const legalEs: LegalContent = {
 
 const legalEn: LegalContent = {
 	title: "Legal framework",
-	updated: "Last updated: March 25, 2026",
+	updated: "Last updated: August 26, 2026",
 	sections: [
 		{
 			heading: "About this tool",
@@ -709,7 +731,7 @@ const legalEn: LegalContent = {
 				"The accuracy of tax declarations submitted through this tool",
 				"Compliance with SUNAT deadlines and tax obligations",
 				"Safeguarding your Clave SOL credentials",
-				"Reviewing all operations via --dry-run before execution",
+				"Reviewing every operation via --dry-run and RHE issuance via --preview-only before submitting",
 			],
 		},
 		{
@@ -743,7 +765,7 @@ const legalEn: LegalContent = {
 				"SUNAT's Operaciones en Linea portal does not explicitly prohibit automated access by authenticated users. However:",
 			],
 			list: [
-				"This tool uses headed Chrome (not headless) to comply with SUNAT's bot detection",
+				"This tool uses headed Chrome when SUNAT requires interactive authentication or confirmation, and direct HTTP for verified intermediate stages",
 				"Operations include realistic delays between form submissions",
 				"No rate-limiting circumvention is attempted",
 				"The tool respects session timeouts and re-authenticates properly",
@@ -758,7 +780,9 @@ const legalEn: LegalContent = {
 		},
 		{
 			heading: "Open source license",
-			paras: ["sunat-cli is released under the MIT License. Source code: github.com/crafter-research/sunat-cli"],
+			paras: [
+				"sunat-cli is released under the MIT License. Source code: github.com/crafter-research/sunat-cli",
+			],
 		},
 	],
 	contact: {


### PR DESCRIPTION
## Summary

- replay the verified RHE deduction, identity and detail stages through direct HTTP
- render and reconcile SUNAT's server preview before the supervised final DOM confirmation
- gate production emission, disable live batches, and publish schema v2
- update the bundled skill, research docs, limitations, and bilingual website
- bump the CLI and website to 0.14.0

## Verification

- `bun test --timeout 15000 tests/unit`: 432 pass, 1 skip
- `bun test --timeout 15000 tests/e2e`: 78 pass, 2 skip
- CLI build and Node smoke pass
- website build: 4 static pages
- live SUNAT `--preview-only` reconciled the draft without calling the final issuance action