### PR TITLE
feat(rhe): download issued XML and PDF

### DIFF
--- a/packages/cli/LIMITATIONS.md
+++ b/packages/cli/LIMITATIONS.md
@@ -186,7 +186,7 @@ These surfaces still need browser bootstrap, but RHE no longer fills identity an
 
 - ⚠️ **Browser boundary** — RHE uses direct HTTP through preview, but Menu SOL bootstrap and the final legal confirmation still depend on the headed portal.
 - ⚠️ **reCAPTCHA via mouse coordinates** — F616 (Nueva Plataforma) requires solving reCAPTCHA. Solved via coordinate injection. Documented as fragile in `CLAUDE.md`.
-- ⚠️ **RHE emission**: direct deduction, identity and details POSTs were replayed with varied inputs and rendered back into the live draft preview for `CONTADO` + `SIN DOCUMENTO`. `GrabaReciboHonorarios` was not called during implementation, so a new production emission is still unverified.
+- ⚠️ **RHE emission**: direct deduction, identity and details POSTs were replayed with varied inputs and rendered back into the live draft preview for `CONTADO` + `SIN DOCUMENTO`. `GrabaReciboHonorarios` was not called during implementation, so a new production emission is still unverified. The confirmation HTML exposes `descargarreciboxml1` and `descargarrecibopdf1`; their POST bodies are implemented, but their real response headers and bytes remain unverified until the next intended issuance.
 - ✅ **F616 declaration**: verified working against the SUNAT portal.
 
 ---

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -28,12 +28,16 @@ sunat-cli schema rhe                     # Introspect fields
 sunat-cli rhe emit --params '{"empresa":"Cliente","descripcion":"Servicio","monto":100}' --dry-run
 sunat-cli rhe emit --params '{"empresa":"Cliente","descripcion":"Servicio","monto":100}' --preview-only
 sunat-cli rhe emit --params '{"empresa":"Cliente","descripcion":"Servicio","monto":100}' --yes --live-sunat
+sunat-cli rhe emit --params '{"empresa":"Cliente","descripcion":"Servicio","monto":100}' --yes --live-sunat --artifacts-dir /absolute/path/rhe
 sunat-cli f616 declare --dry-run --params '{"periodo":"2025-03"}'
 sunat-cli api token --output json        # Validate OAuth2 credentials without printing the token
 ```
 
 RHE is hybrid: a headed SOL session mints the entry URL, direct HTTP reaches the
-legally invalid preview, and the final browser confirmation remains gated.
+legally invalid preview, and the final browser confirmation remains gated. Once
+issued, the same session downloads and validates the XML and PDF. The JSON result
+contains their private local paths and reports artifact errors separately from
+the legal issuance status.
 
 ### Buzón SOL metadata (read-only)
 

--- a/packages/cli/RESEARCH.md
+++ b/packages/cli/RESEARCH.md
@@ -110,6 +110,8 @@ All form transitions POST to
 | Details | `CapturaDatosReciboHonorarios` | `motivo`, `fecemi`, `cantidad`, `moneda`, `mediopago`, renta/payment indicators |
 | Submit | `GrabaReciboHonorarios` | reached only from the rendered `Emitir Recibo` preview |
 | Confirmation | rendered document | exposes download, print and `Registrar Pagos` controls |
+| XML | `descargarreciboxml1` | confirmation form POST with no additional fields |
+| PDF | `descargarrecibopdf1` | confirmation form POST with no additional fields |
 
 The captured recipient path was `SIN DOCUMENTO`. RUC and DNI add a separate
 `Validar RUC o DNI` transition that was not present, so the CLI must not claim
@@ -126,6 +128,11 @@ browser open for supervision, sends deduction, identity and details directly by
 HTTP, renders the returned draft back into the iframe, then reconciles client,
 description, date, currency and totals. `GrabaReciboHonorarios` remains a DOM
 confirmation and runs only when both `--yes` and `--live-sunat` are present.
+After confirmation, both artifact actions can run by direct HTTP in the same
+session. The HAR contains their forms but not the resulting requests, so live
+response MIME and content-disposition remain unverified. The implementation
+accepts only structurally valid XML and `%PDF-` bytes and treats download errors
+as post-submit artifact failures rather than failed issuance.
 
 ### Gotchas
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/sunat-cli",
-	"version": "0.14.0",
+	"version": "0.15.0",
 	"description": "Agent-first CLI for SUNAT tax automation",
 	"module": "bin/sunat.ts",
 	"type": "module",

--- a/packages/cli/skills/sunat-cli/SKILL.md
+++ b/packages/cli/skills/sunat-cli/SKILL.md
@@ -59,8 +59,11 @@ sunat-cli rhe emit --params '...' --dry-run
 # Reach SUNAT's server preview by direct HTTP and render it for review
 sunat-cli rhe emit --params '...' --preview-only
 
-# Emit only after visually checking the preview
+# Emit only after visually checking the preview; XML and PDF go to Downloads/sunat-rhe
 sunat-cli rhe emit --params '...' --yes --live-sunat
+
+# Choose another private artifact directory
+sunat-cli rhe emit --params '...' --yes --live-sunat --artifacts-dir /absolute/path/rhe
 
 # Validate a CSV batch locally
 sunat-cli rhe emit --batch recibos.csv --dry-run
@@ -73,6 +76,7 @@ Key rules:
 - `fechaEmision`: Sent as DD/MM/YYYY and reconciled against the rendered preview. The observed portal accepts today or the previous 2 days.
 - The observed path is `CONTADO`, non-gratuito, inciso A, no withholding and fully paid at emission.
 - Auth: headed SOL bootstrap; direct HTTP through preview; browser confirmation for the final legal submission.
+- After confirmation, the same session downloads and validates the XML and PDF. JSON output returns private local paths and reports artifact failures separately from issuance status.
 - Live batches are disabled. Validate CSV with `--dry-run`, then preview and emit each RHE individually.
 
 ### F616 (Monthly Tax Declaration)

--- a/packages/cli/skills/sunat-cli/references/schemas.md
+++ b/packages/cli/skills/sunat-cli/references/schemas.md
@@ -16,7 +16,9 @@ Portal: SOL viejo (e-menu.sunat.gob.pe/cl-ti-itmenu/) -- no captcha.
 
 `--dry-run` validates locally. `--preview-only` sends the stateful form endpoint
 through the server draft, renders it in the iframe and stops at the reconciled
-`Emitir Recibo` page. Submission requires `--yes --live-sunat`.
+`Emitir Recibo` page. Submission requires `--yes --live-sunat`. A successful
+submission downloads its XML and PDF to `~/Downloads/sunat-rhe` by default;
+`--artifacts-dir <absolute-path>` changes the destination.
 
 ## F616 Declare Fields
 

--- a/packages/cli/src/commands/rhe/index.ts
+++ b/packages/cli/src/commands/rhe/index.ts
@@ -1,4 +1,6 @@
 import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { Command } from "commander";
 import { ensureSOLSession } from "../../browser/auth.ts";
 import { audit } from "../../data/audit.ts";
@@ -27,6 +29,7 @@ export function createRheCommand(): Command {
 		.option("--batch <file>", "CSV file with multiple RHEs")
 		.option("--dry-run", "Validate locally without opening SUNAT")
 		.option("--preview-only", "Fill SUNAT and stop at the reconciled preview")
+		.option("--artifacts-dir <dir>", "Directory for the issued XML and PDF", join(homedir(), "Downloads", "sunat-rhe"))
 		.option("--yes", "Confirm the requested live operation")
 		.option("--live-sunat", "Acknowledge that this writes to production SUNAT")
 		.action(async (opts, cmd) => {
@@ -63,10 +66,12 @@ export function createRheCommand(): Command {
 						audit({ command: "rhe emit", args: input as unknown as Record<string, unknown>, result: "dry-run" });
 						output(format, { json: { dryRun: true, input, status: "would-emit" } });
 					} else {
+						const artifactsDir = sanitizePath(String(opts.artifactsDir));
 						const creds = getCredentials();
 						await ensureSOLSession(creds);
 						const result = await emitRHE(input, {
 							previewOnly,
+							artifactsDir: previewOnly ? undefined : artifactsDir,
 							beforeSubmit: () =>
 								audit({
 									command: "rhe emit",

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -68,7 +68,7 @@ type SchemaName = (typeof AVAILABLE_SCHEMAS)[number];
 // only when the described contract changes, so an agent diffing it does not
 // see churn from unrelated releases. Bump on any field, flag or shape change.
 const SCHEMA_VERSIONS: Record<SchemaName, string> = {
-	rhe: "2.0.0",
+	rhe: "3.0.0",
 	f616: "1.0.0",
 	renta: "1.0.0",
 	buzon: "1.0.0",

--- a/packages/cli/src/schemas/rhe.json
+++ b/packages/cli/src/schemas/rhe.json
@@ -58,6 +58,7 @@
 	"flags": {
 		"--dry-run": "Validate and print the payload without opening SUNAT",
 		"--preview-only": "Fill SUNAT, reconcile the rendered preview, and stop before Emitir Recibo",
+		"--artifacts-dir <dir>": "Private destination for XML and PDF after issuance; defaults to ~/Downloads/sunat-rhe",
 		"--yes --live-sunat": "Required together to invoke the production submission",
 		"--output json": "Machine-readable JSON output",
 		"--batch <file>": "Validate multiple RHEs from CSV with --dry-run; live batches are disabled"

--- a/packages/cli/src/skills/core.md
+++ b/packages/cli/src/skills/core.md
@@ -62,8 +62,11 @@ sunat-cli rhe emit --params '...' --dry-run
 # Reach SUNAT's server preview by direct HTTP and render it for review
 sunat-cli rhe emit --params '...' --preview-only
 
-# Emit only after visually checking the preview
+# Emit only after visually checking the preview; XML and PDF go to Downloads/sunat-rhe
 sunat-cli rhe emit --params '...' --yes --live-sunat
+
+# Choose another private artifact directory
+sunat-cli rhe emit --params '...' --yes --live-sunat --artifacts-dir /absolute/path/rhe
 
 # Validate a CSV batch locally
 sunat-cli rhe emit --batch recibos.csv --dry-run
@@ -81,6 +84,7 @@ Key rules:
 - `fechaEmision` is sent as `fecemi` in DD/MM/YYYY and reconciled against the rendered server preview.
 - The observed flow is `CONTADO`, non-gratuito, inciso A, no withholding and fully paid at emission.
 - Auth: headed SOL bootstrap; deduction, identity and details go by direct HTTP; final confirmation remains supervised in the browser.
+- After confirmation, the CLI posts `descargarreciboxml1` and `descargarrecibopdf1` through the same form session, validates both files and returns their private local paths. Artifact failure is reported separately from issuance status.
 - Live batches are disabled. Validate CSV with `--dry-run`, then preview and emit each RHE individually.
 
 ### F616 (Monthly Tax Declaration)
@@ -209,7 +213,7 @@ form between periods**. Eight periods spanning nine months were filed this way o
 **Emit an RHE**:
 1. `sunat-cli login`
 2. `sunat-cli rhe emit --params '{"empresa":"Cliente Ejemplo","tipoDoc":"SIN DOCUMENTO","descripcion":"Servicios de desarrollo de software - Agosto 2026","monto":6700,"moneda":"PEN","medioPago":"TRANSFERENCIA"}' --preview-only`
-3. Check the headed browser, then rerun with `--yes --live-sunat`
+3. Check the headed browser, then rerun with `--yes --live-sunat`; the result includes the XML and PDF paths
 
 ## Error Handling
 

--- a/packages/cli/src/skills/endpoints.md
+++ b/packages/cli/src/skills/endpoints.md
@@ -99,11 +99,17 @@ stage posts to `/ol-ti-itreciboelectronico/cpelec001Alias`:
 | Identity | `CapturaDatosReciboHonorariosIdentidad` |
 | Details and server preview | `CapturaDatosReciboHonorarios` |
 | Production submission | `GrabaReciboHonorarios` |
+| Issued XML | `descargarreciboxml1` |
+| Issued PDF | `descargarrecibopdf1` |
 
 The entry URL carries six required query fields: `accion`, `p`, `tenc`, `prg`,
 `fecenv` and `usub`. Treat the whole URL as a secret. Direct HTTP is verified
 through preview for `CONTADO` + `SIN DOCUMENTO`; the final submission remains a
-browser confirmation. The raw HAR is private and excluded from the repository.
+browser confirmation. The confirmation HTML contains two same-endpoint POST
+forms with only the XML and PDF actions above. The original HAR did not capture
+their responses, so the CLI validates the returned XML structure and PDF
+signature before saving them. The raw HAR is private and excluded from the
+repository.
 
 ### Reporte Tributario para Terceros
 

--- a/packages/cli/src/skills/schemas.md
+++ b/packages/cli/src/skills/schemas.md
@@ -16,7 +16,9 @@ Portal: SOL viejo (e-menu.sunat.gob.pe/cl-ti-itmenu/) -- no captcha.
 
 `--dry-run` validates locally. `--preview-only` sends the stateful form endpoint
 through the server draft, renders it in the iframe and stops at the reconciled
-`Emitir Recibo` page. Submission requires `--yes --live-sunat`.
+`Emitir Recibo` page. Submission requires `--yes --live-sunat`. A successful
+submission downloads its XML and PDF to `~/Downloads/sunat-rhe` by default;
+`--artifacts-dir <absolute-path>` changes the destination.
 
 ## F616 Declare Fields
 

--- a/packages/cli/src/workflows/rhe.ts
+++ b/packages/cli/src/workflows/rhe.ts
@@ -1,5 +1,8 @@
+import { resolve } from "node:path";
+import { XMLValidator } from "fast-xml-parser";
 import { type CdpSession, connect } from "../browser/cdp.ts";
 import * as browser from "../browser/client.ts";
+import { writePrivateOutputFile } from "../data/private-storage.ts";
 import type { MedioPago, TipoDocumento } from "../validation/input.ts";
 
 export interface RHEInput {
@@ -27,6 +30,30 @@ export interface RHEResult extends Omit<RHEPreview, "status"> {
 	status: "issued" | "submitted-unverified";
 	serie?: string;
 	numero?: string;
+	artifacts?: RHEArtifactsResult;
+}
+
+export type RHEArtifactKind = "xml" | "pdf";
+
+export interface RHEArtifactFile {
+	path: string;
+	bytes: number;
+	contentType: string;
+}
+
+export interface RHEArtifactsResult {
+	status: "downloaded" | "partial" | "unavailable";
+	directory: string;
+	xml?: RHEArtifactFile;
+	pdf?: RHEArtifactFile;
+	errors?: Partial<Record<RHEArtifactKind, string>>;
+}
+
+interface RHEArtifactResponse {
+	ok: boolean;
+	status: number;
+	contentType: string;
+	base64: string;
 }
 
 const DOCUMENTO_SUNAT: Record<TipoDocumento, string> = {
@@ -141,9 +168,37 @@ export function extractRHEConfirmation(text: string): { serie?: string; numero?:
 	return { serie: match[1].toUpperCase(), numero: match[2] };
 }
 
+export function buildRHEArtifactParams(kind: RHEArtifactKind): URLSearchParams {
+	return new URLSearchParams({ accion: kind === "xml" ? "descargarreciboxml1" : "descargarrecibopdf1" });
+}
+
+export function decodeRHEArtifact(kind: RHEArtifactKind, response: RHEArtifactResponse): Buffer {
+	if (!response.ok || response.status !== 200) {
+		throw new Error(`SUNAT ${kind.toUpperCase()} download returned HTTP ${response.status || "network-error"}`);
+	}
+	const data = Buffer.from(response.base64, "base64");
+	if (data.length === 0) throw new Error(`SUNAT ${kind.toUpperCase()} download returned an empty file`);
+	const prefix = data
+		.subarray(0, 512)
+		.toString("utf8")
+		.replace(/^\uFEFF/, "")
+		.trimStart();
+	if (response.contentType.toLowerCase().includes("text/html") || /^<!doctype html|^<html\b/i.test(prefix)) {
+		throw new Error(`SUNAT returned an HTML page instead of the ${kind.toUpperCase()} artifact`);
+	}
+	if (kind === "pdf" && !data.subarray(0, 5).equals(Buffer.from("%PDF-"))) {
+		throw new Error("SUNAT PDF download did not contain a PDF signature");
+	}
+	if (kind === "xml") {
+		const validation = XMLValidator.validate(data.toString("utf8").replace(/^\uFEFF/, ""));
+		if (validation !== true) throw new Error("SUNAT XML download did not contain valid XML");
+	}
+	return data;
+}
+
 export async function emitRHE(
 	input: RHEInput,
-	opts: { previewOnly?: boolean; beforeSubmit?: () => void | Promise<void> } = {},
+	opts: { previewOnly?: boolean; artifactsDir?: string; beforeSubmit?: () => void | Promise<void> } = {},
 ): Promise<RHEPreview | RHEResult> {
 	if (input.tipoDoc !== "SIN DOCUMENTO") {
 		throw new Error(
@@ -235,11 +290,80 @@ export async function emitRHE(
 		return JSON.parse(String(raw)) as { serie?: string; numero?: string };
 	});
 
+	let artifacts: RHEArtifactsResult | undefined;
+	if (opts.artifactsDir) {
+		try {
+			artifacts = await downloadRHEArtifacts(opts.artifactsDir, confirmation, input.fechaEmision);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "RHE artifact download failed";
+			artifacts = {
+				status: "unavailable",
+				directory: resolve(opts.artifactsDir),
+				errors: { xml: message, pdf: message },
+			};
+		}
+	}
+
 	return {
 		...preview,
 		status: confirmation.serie && confirmation.numero ? "issued" : "submitted-unverified",
 		...confirmation,
+		...(artifacts ? { artifacts } : {}),
 	};
+}
+
+async function downloadRHEArtifacts(
+	directory: string,
+	confirmation: { serie?: string; numero?: string },
+	fechaEmision: string,
+): Promise<RHEArtifactsResult> {
+	const xmlAction = buildRHEArtifactParams("xml").get("accion");
+	const pdfAction = buildRHEArtifactParams("pdf").get("accion");
+	const responses = await onRHEPage(
+		`!!document.forms.lista4&&!!document.forms.lista5&&/descargarreciboxml1/i.test(document.forms.lista4.innerHTML)&&/descargarrecibopdf1/i.test(document.forms.lista5.innerHTML)`,
+		async (session) => {
+			const raw = await evaluate(
+				session,
+				`(async function(){var endpoint='/ol-ti-itreciboelectronico/cpelec001Alias';var download=async function(action){try{var response=await fetch(endpoint,{method:'POST',credentials:'include',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:new URLSearchParams({accion:action})});var blob=await response.blob();var base64=await new Promise(function(resolve,reject){var reader=new FileReader();reader.onload=function(){var value=String(reader.result||'');resolve(value.slice(value.indexOf(',')+1))};reader.onerror=function(){reject(new Error('read-failed'))};reader.readAsDataURL(blob)});return {ok:response.ok,status:response.status,contentType:response.headers.get('content-type')||'',base64:base64}}catch(error){return {ok:false,status:0,contentType:'',base64:''}}};var xml=await download(${JSON.stringify(xmlAction)});var pdf=await download(${JSON.stringify(pdfAction)});return JSON.stringify({xml:xml,pdf:pdf})})()`,
+			);
+			return JSON.parse(String(raw)) as Record<RHEArtifactKind, RHEArtifactResponse>;
+		},
+	);
+
+	const targetDirectory = resolve(directory);
+	const stem =
+		confirmation.serie && confirmation.numero
+			? `RHE-${confirmation.serie}-${confirmation.numero}`
+			: `RHE-${fechaEmision}-${Date.now()}`;
+	const result: RHEArtifactsResult = { status: "unavailable", directory: targetDirectory };
+	const errors: Partial<Record<RHEArtifactKind, string>> = {};
+	for (const kind of ["xml", "pdf"] as const) {
+		try {
+			const data = decodeRHEArtifact(kind, responses[kind]);
+			const path = resolve(targetDirectory, `${stem}.${kind}`);
+			writePrivateOutputFile(path, data);
+			result[kind] = {
+				path,
+				bytes: data.length,
+				contentType: normalizeRHEArtifactContentType(kind, responses[kind].contentType),
+			};
+		} catch (error) {
+			errors[kind] = error instanceof Error ? error.message : `RHE ${kind.toUpperCase()} download failed`;
+		}
+	}
+	const count = Number(Boolean(result.xml)) + Number(Boolean(result.pdf));
+	result.status = count === 2 ? "downloaded" : count === 1 ? "partial" : "unavailable";
+	if (Object.keys(errors).length > 0) result.errors = errors;
+	return result;
+}
+
+function normalizeRHEArtifactContentType(kind: RHEArtifactKind, value: string): string {
+	const contentType = value.split(";", 1)[0].trim().toLowerCase();
+	return /^[a-z0-9.+-]+\/[a-z0-9.+-]+$/.test(contentType)
+		? contentType
+		: kind === "xml"
+			? "application/xml"
+			: "application/pdf";
 }
 
 async function onRHEPage<T>(probe: string, run: (session: CdpSession) => Promise<T>): Promise<T> {

--- a/packages/cli/tests/e2e/params-flag.test.ts
+++ b/packages/cli/tests/e2e/params-flag.test.ts
@@ -134,13 +134,14 @@ describe("RHE live boundary", () => {
 	test("documents the portal preview and live acknowledgements", async () => {
 		const { stdout } = await run(["rhe", "emit", "--help"]);
 		expect(stdout).toContain("--preview-only");
+		expect(stdout).toContain("--artifacts-dir <dir>");
 		expect(stdout).toContain("--yes");
 		expect(stdout).toContain("--live-sunat");
 	});
 
-	test("publishes the gated RHE contract as schema v2", async () => {
+	test("publishes the artifact-aware RHE contract as schema v3", async () => {
 		const { stdout } = await run(["schema", "rhe"]);
-		expect(JSON.parse(stdout).version).toBe("2.0.0");
+		expect(JSON.parse(stdout).version).toBe("3.0.0");
 	});
 
 	test("rejects unsupported document-backed recipients during dry-run", async () => {

--- a/packages/cli/tests/unit/rhe.test.ts
+++ b/packages/cli/tests/unit/rhe.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
+	buildRHEArtifactParams,
 	buildRHEDetailsParams,
 	buildRHEIdentityParams,
+	decodeRHEArtifact,
 	extractRHEConfirmation,
 	parsePortalAmount,
 	type RHEInput,
@@ -57,5 +59,54 @@ describe("RHE portal contract", () => {
 			numero: "123456",
 		});
 		expect(extractRHEConfirmation("Emitido sin identificador visible")).toEqual({});
+	});
+
+	test("builds the XML and PDF download transitions observed in the confirmation HTML", () => {
+		expect(buildRHEArtifactParams("xml").toString()).toBe("accion=descargarreciboxml1");
+		expect(buildRHEArtifactParams("pdf").toString()).toBe("accion=descargarrecibopdf1");
+	});
+
+	test("accepts valid RHE artifact bytes", () => {
+		const xml = Buffer.from('<?xml version="1.0"?><rhe><serie>E001</serie></rhe>');
+		const pdf = Buffer.from("%PDF-1.7\nfixture");
+		expect(
+			decodeRHEArtifact("xml", {
+				ok: true,
+				status: 200,
+				contentType: "application/xml",
+				base64: xml.toString("base64"),
+			}),
+		).toEqual(xml);
+		expect(
+			decodeRHEArtifact("pdf", {
+				ok: true,
+				status: 200,
+				contentType: "application/pdf",
+				base64: pdf.toString("base64"),
+			}),
+		).toEqual(pdf);
+	});
+
+	test("rejects portal error pages and malformed artifacts", () => {
+		const html = Buffer.from("<!doctype html><html><body>Error</body></html>").toString("base64");
+		expect(() => decodeRHEArtifact("xml", { ok: true, status: 200, contentType: "text/html", base64: html })).toThrow(
+			"HTML page",
+		);
+		expect(() =>
+			decodeRHEArtifact("pdf", {
+				ok: true,
+				status: 200,
+				contentType: "application/octet-stream",
+				base64: Buffer.from("not-pdf").toString("base64"),
+			}),
+		).toThrow("PDF signature");
+		expect(() =>
+			decodeRHEArtifact("xml", {
+				ok: true,
+				status: 200,
+				contentType: "application/octet-stream",
+				base64: Buffer.from("not-xml").toString("base64"),
+			}),
+		).toThrow("valid XML");
 	});
 });

--- a/packages/website/src/lib/content.ts
+++ b/packages/website/src/lib/content.ts
@@ -1,6 +1,6 @@
 import type { Locale } from "./i18n";
 
-export const VERSION = "0.14.0";
+export const VERSION = "0.15.0";
 
 /**
  * Copy lives per locale rather than as a key/value dictionary with one canonical
@@ -131,7 +131,7 @@ const es: Content = {
 			{
 				title: "Rentas de cuarta",
 				scope: "RHE y F616",
-				desc: "En RHE, el navegador obtiene la entrada SOL, HTTP llega hasta el borrador y la confirmación legal queda visible y bloqueada. F616 conserva su lectura headless por API.",
+				desc: "En RHE, el navegador obtiene la entrada SOL, HTTP llega al borrador, la confirmación legal queda supervisada y la descarga XML/PDF está conectada para validarla en la próxima emisión real. F616 conserva su lectura headless por API.",
 				code: '$ sunat-cli rhe emit \\\n    --params \'{"empresa":"Cliente","descripcion":"Servicio","monto":100}\' --preview-only',
 			},
 			{
@@ -164,7 +164,7 @@ const es: Content = {
 		heading: "Endpoints primero, navegador en el borde",
 		prose: [
 			"La página del F616 parece un formulario. Es una aplicación de una sola página hablando con una API JSON, y los campos del formulario son la forma menos confiable de llegar ahí.",
-			"RHE es distinto: Menu SOL genera una entrada efímera y el backend responde HTML. La CLI usa HTTP para deducción, identidad y detalles, vuelve a renderizar el borrador y reserva el DOM para la confirmación legal final.",
+			"RHE es distinto: Menu SOL genera una entrada efímera y el backend responde HTML. La CLI usa HTTP para deducción, identidad y detalles, vuelve a renderizar el borrador, reserva el DOM para la confirmación legal y conecta XML/PDF por endpoint después de emitir.",
 		],
 		steps: [
 			{
@@ -180,7 +180,7 @@ const es: Content = {
 			{
 				n: "03",
 				title: "Confirmar",
-				desc: "Para RHE, renderiza el borrador y mantiene la acción legal final bajo control humano.",
+				desc: "Para RHE, mantiene la acción legal bajo control humano y después valida y guarda los archivos si SUNAT responde con XML/PDF reales.",
 			},
 		],
 	},
@@ -210,7 +210,7 @@ const es: Content = {
 			},
 			{
 				domain: "RHE y F616",
-				detail: "RHE hasta borrador; F616 lectura API",
+				detail: "RHE supervisado; XML/PDF conectado, falta live",
 				pct: 85,
 				state: "partial",
 			},
@@ -404,7 +404,7 @@ const en: Content = {
 			{
 				title: "Independent worker filings",
 				scope: "RHE and F616",
-				desc: "For RHE, the browser obtains the SOL entry, HTTP reaches the draft, and the legal confirmation stays visible and gated. F616 keeps its headless API read path.",
+				desc: "For RHE, the browser obtains the SOL entry, HTTP reaches the draft, the legal confirmation stays supervised, and XML/PDF download is wired for validation on the next real issuance. F616 keeps its headless API read path.",
 				code: '$ sunat-cli rhe emit \\\n    --params \'{"empresa":"Client","descripcion":"Service","monto":100}\' --preview-only',
 			},
 			{
@@ -437,7 +437,7 @@ const en: Content = {
 		heading: "Endpoints first, browser at the boundary",
 		prose: [
 			"The F616 declaration page looks like a form. It is a single-page app talking to a JSON API, and the form fields are the least reliable way to reach it.",
-			"RHE is different: Menu SOL mints an ephemeral entry and the backend returns HTML. The CLI uses HTTP for deduction, identity, and details, renders the draft again, and reserves DOM automation for the final legal confirmation.",
+			"RHE is different: Menu SOL mints an ephemeral entry and the backend returns HTML. The CLI uses HTTP for deduction, identity, and details, renders the draft again, reserves DOM automation for the legal confirmation, and wires XML/PDF through endpoints after issuance.",
 		],
 		steps: [
 			{
@@ -453,7 +453,7 @@ const en: Content = {
 			{
 				n: "03",
 				title: "Confirm",
-				desc: "For RHE, render the draft and keep the final legal action under human control.",
+				desc: "For RHE, keep the legal action under human control, then validate and save artifacts only when SUNAT returns real XML/PDF bytes.",
 			},
 		],
 	},
@@ -478,7 +478,7 @@ const en: Content = {
 			},
 			{
 				domain: "RHE and F616",
-				detail: "RHE through draft; F616 API reads",
+				detail: "Supervised RHE; XML/PDF wired, live pending",
 				pct: 85,
 				state: "partial",
 			},

--- a/skills/sunat-cli/SKILL.md
+++ b/skills/sunat-cli/SKILL.md
@@ -50,3 +50,7 @@ locally, T2 files with SUNAT and needs `--yes`, T3 is irreversible and needs a
 single-use intent token. Preview before you file; `--dry-run` calls the real path.
 
 Production is beta throughout. Never run it blind.
+
+For live RHE emission, the CLI keeps the legal confirmation supervised and then
+downloads the issued XML and PDF through the same SUNAT session. Read the bundled
+core and endpoint manuals for the artifact result contract and verification status.


### PR DESCRIPTION
## Summary

- post the observed `descargarreciboxml1` and `descargarrecibopdf1` actions after supervised RHE issuance
- validate XML structure and PDF signature before writing owner-only local files
- report artifact failures separately from legal issuance status to avoid duplicate retries
- publish schema v3 plus CLI skill, README, limitations, recon-derived endpoint docs, and bilingual website copy
- bump CLI and website to v0.15.0

## Verification

- `bun test --timeout 15000`: 513 pass, 3 opt-in skips, 0 fail
- CLI build and Node-only smoke
- npm pack dry run contains `dist/sunat.js`
- Astro website build: 4 routes

## Live boundary

The authorized HAR contains both post-issuance forms but not their response bytes. The next intended real RHE emission must verify response MIME, content-disposition, XML, and PDF. The implementation rejects HTML/malformed artifacts and never reports a post-submit download problem as failed issuance.