### PR TITLE
fix(release): skip artifact verification without publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,7 @@ jobs:
         run: npm publish "$GITHUB_WORKSPACE/.release/crafter-sunat-cli-$VERSION.tgz" --access public --ignore-scripts --provenance --registry https://registry.npmjs.org
 
       - name: Verify published artifact
+        if: steps.version.outputs.publish == 'true'
         working-directory: .
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The release workflow already detects an unchanged package version and skips npm publish, but the next artifact-verification step still compares the newly built tarball against the previously published version and fails. Gate verification with the same publish output.\n\nVerification: release workflow YAML parses successfully. After merge, dispatch the workflow on main and require a successful no-publish run.