### PR TITLE
docs: restore SUNAT implementation context

### DIFF
--- a/packages/cli/scripts/smoke-sire-propuesta.sh
+++ b/packages/cli/scripts/smoke-sire-propuesta.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env bash
+# Smoke test: download the RVIE and RCE proposals for a period, end to end, with
+# the build that ships (node dist/sunat.js, not bun bin/sunat.ts).
+#
+# One command per book does the three steps SUNAT requires: ask for the export
+# (Manual API Registro de Ventas v30 §5.18 / Manual SIRE Compras v28 §5.34),
+# poll the ticket by period (§5.16), download the file it produced (§5.17). The
+# result must be a ZIP.
+#
+# Needs real SIRE credentials in the environment, the same five the CLI reads:
+#   SUNAT_API_CLIENT_ID, SUNAT_API_CLIENT_SECRET, SUNAT_RUC, SUNAT_USER, SUNAT_PASSWORD
+# It skips, without failing, when they are absent. It prints ticket numbers and
+# byte counts only: no RUC, no names, no amounts. The downloaded files are
+# deleted on exit.
+#
+# Run from packages/cli directory:
+#   bash scripts/smoke-sire-propuesta.sh [YYYYMM]     # default: previous month
+# Or via npm script:
+#   bun smoke:sire-propuesta
 
 set -euo pipefail
 

--- a/packages/cli/scripts/smoke-tipo-cambio.sh
+++ b/packages/cli/scripts/smoke-tipo-cambio.sh
@@ -1,7 +1,22 @@
 #!/usr/bin/env bash
+# Smoke test: fetch a tipo de cambio from SUNAT with the build that ships.
+#
+# The WAF in front of e-consulta.sunat.gob.pe rejects requests that carry no
+# Accept-Encoding header. Bun's fetch adds one on its own; Node's does not. So
+# this test deliberately runs dist/sunat.js under node, not bin/sunat.ts under
+# bun: the failure it guards against only exists in the published artifact.
+#
+# Run from packages/cli directory:
+#   bash scripts/smoke-tipo-cambio.sh [YYYY-MM-DD]
+# Or via npm script:
+#   bun smoke:tipo-cambio
+#
+# No credentials needed: the endpoint is public.
 
 set -euo pipefail
 
+# A scratch state root, so the request is not answered from an operator's
+# cache: a cache hit would pass this test without touching the network.
 export SUNAT_HOME="$(mktemp -d "${TMPDIR:-/tmp}/sunat-smoke-tc.XXXXXX")"
 trap 'rm -rf "$SUNAT_HOME"' EXIT
 
@@ -11,6 +26,8 @@ echo "→ Building dist/sunat.js..."
 bun run scripts/build.ts >/dev/null
 
 echo "→ node dist/sunat.js tipo-cambio --fecha $FECHA (fresh SUNAT_HOME, no cache)..."
+# Errors are reported as JSON on stderr; capture both streams so the verdict
+# below reads the real answer rather than an empty string.
 RESULT=$(node dist/sunat.js -o json tipo-cambio --fecha "$FECHA" 2>&1 || true)
 echo "$RESULT" | bun -e '
 const r = JSON.parse(await Bun.stdin.text());

--- a/packages/cli/src/sunat-rest/sire.ts
+++ b/packages/cli/src/sunat-rest/sire.ts
@@ -103,6 +103,15 @@ export interface TicketResponse {
 	numTicket: string;
 }
 
+/**
+ * Each book exports its proposal from its own propuesta module, with the period
+ * in the path: Manual API Registro de Ventas v30 §5.18 and Manual SIRE Compras
+ * v28 §5.34. The shared `rvierce/gestionprocesosmasivos/.../exportapropuesta`
+ * route of the v22 manual is gone; the gateway answers it, like any unknown
+ * route, with a bare nginx 500 that reads as an outage. The format parameter is
+ * `codTipoArchivo`, and RCE rejects the call with 422 without `codOrigenEnvio`.
+ * Verified against production 2026-08-25.
+ */
 export async function descargarPropuesta(opts: DescargarOpts, creds: OAuthCredentials): Promise<string> {
 	const libro = opts.codLibro === COD_LIBRO.rvie ? "rvie" : "rce";
 	const action = opts.codLibro === COD_LIBRO.rvie ? "exportapropuesta" : "exportacioncomprobantepropuesta";
@@ -140,6 +149,7 @@ export async function descargarRvie(perTributario: string, creds: OAuthCredentia
 
 export interface TicketArchivo {
 	nomArchivoReporte: string;
+	/** As SUNAT returns it, with its misspelling. The download endpoint accepts either spelling. */
 	codTipoAchivoReporte?: string;
 	codTipoArchivoReporte?: string;
 	nomArchivoContenido?: string;
@@ -149,6 +159,7 @@ export interface TicketStatus {
 	numTicket: string;
 	codEstadoProceso: string; // "01" iniciado, "03" en proceso, "06" terminado, "07" error, "10" terminado con error
 	desEstadoProceso: string;
+	/** The process that produced the ticket (Anexo I). The download endpoint needs it back. */
 	codProceso?: string;
 	desProceso?: string;
 	perTributario?: string;
@@ -157,6 +168,12 @@ export interface TicketStatus {
 	archivoReporte?: TicketArchivo[];
 }
 
+/**
+ * `consultaestadotickets` is a listing per period: `perIni`/`perFin` are
+ * mandatory (Manual API Registro de Ventas v30 §5.16) and a request carrying
+ * only `numTicket` is answered 422. The ticket number does not encode the
+ * period, so callers must know which period the ticket belongs to.
+ */
 export async function consultarTicket(
 	numTicket: string,
 	creds: OAuthCredentials,
@@ -187,10 +204,18 @@ export interface DescargarArchivoOpts {
 	codTipoArchivoReporte: string;
 	codLibro: CodLibro;
 	perTributario: string;
+	/** The `codProceso` of the ticket that produced the file, e.g. "10" for an exported proposal. Mandatory. */
 	codProceso: string;
+	/** The ticket itself. Mandatory. */
 	numTicket: string;
 }
 
+/**
+ * Manual API Registro de Ventas v30 §5.17 lists `perTributario`, `codProceso`
+ * and `numTicket` as mandatory alongside the file name; the URL template in
+ * the same section omits them, and so did this function. Without either of
+ * the two the server answers 500. Verified against production 2026-08-26.
+ */
 export async function descargarArchivo(opts: DescargarArchivoOpts, creds: OAuthCredentials): Promise<Buffer> {
 	const token = await getAccessToken(creds);
 	const url = new URL(
@@ -211,6 +236,11 @@ export async function descargarArchivo(opts: DescargarArchivoOpts, creds: OAuthC
 	return Buffer.from(ab);
 }
 
+/**
+ * The download options for the n-th file a finished ticket produced, or null
+ * when the ticket lists no such file. The ticket carries everything the
+ * download needs; this keeps callers from re-assembling six parameters.
+ */
 export function archivoDeTicket(
 	ticket: { numTicket: string; codProceso?: string; archivoReporte?: TicketArchivo[] },
 	codLibro: CodLibro,
@@ -269,6 +299,7 @@ export interface PollTicketResult {
 export interface PollTicketOpts {
 	creds: OAuthCredentials;
 	numTicket: string;
+	/** The period the ticket belongs to; the status endpoint cannot be queried without it. */
 	perTributario: string;
 	timeoutMs?: number;
 	initialDelayMs?: number;

--- a/packages/cli/src/sunat-rest/tipo-cambio.ts
+++ b/packages/cli/src/sunat-rest/tipo-cambio.ts
@@ -52,6 +52,8 @@ const BROWSER_HEADERS: Record<string, string> = {
 		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
 	Accept: "application/json, text/javascript, */*; q=0.01",
 	"Accept-Language": "es-ES,es;q=0.9,en;q=0.8",
+	// SUNAT's WAF rejects requests without Accept-Encoding. Bun's fetch adds it
+	// by default; Node's (undici) does not, so the Node build was rejected.
 	"Accept-Encoding": "gzip, deflate, br",
 	"Content-Type": "application/json; charset=utf-8",
 	"X-Requested-With": "XMLHttpRequest",

--- a/packages/cli/tests/unit/sire.test.ts
+++ b/packages/cli/tests/unit/sire.test.ts
@@ -93,6 +93,10 @@ describe("listarPeriodos", () => {
 });
 
 describe("descargarPropuesta", () => {
+	// Manual API Registro de Ventas v30 §5.18: the export lives in the book's
+	// propuesta module with the period in the path, and the format parameter is
+	// codTipoArchivo. The v22 route under gestionprocesosmasivos is answered by
+	// the gateway with a bare nginx 500, like any route that does not exist.
 	test("RVIE exports from /rvie/propuesta/.../{periodo}/exportapropuesta and returns ticket", async () => {
 		let seenUrl = "";
 		mockFetch(async (url) => {
@@ -108,6 +112,8 @@ describe("descargarPropuesta", () => {
 		expect(seenUrl).not.toContain("codTipoArchivoReporte");
 	});
 
+	// Manual SIRE Compras v28 §5.34. SUNAT answers 422 "El campo 'codOrigenEnvio'
+	// es nulo o vacio" when the origin is missing.
 	test("RCE exports from /rce/propuesta/.../{periodo}/exportacioncomprobantepropuesta with codOrigenEnvio", async () => {
 		let seenUrl = "";
 		mockFetch(async (url) => {
@@ -155,6 +161,8 @@ describe("aceptarPropuestaRvie", () => {
 });
 
 describe("consultarTicket", () => {
+	// Manual API Registro de Ventas v30 §5.16: consultaestadotickets lists tickets
+	// per period; perIni/perFin are mandatory and a query by numTicket alone is 422.
 	test("queries the period window and returns the matching registro", async () => {
 		let seenUrl = "";
 		mockFetch(async (url) => {
@@ -186,6 +194,8 @@ describe("consultarTicket", () => {
 });
 
 describe("descargarArchivo", () => {
+	// Manual API Registro de Ventas v30 §5.17 lists perTributario, codProceso and
+	// numTicket as mandatory; the server answers 500 without codProceso or numTicket.
 	test("sends codProceso and numTicket alongside the file name", async () => {
 		let seenUrl = "";
 		mockFetch(async (url) => {

--- a/packages/cli/tests/unit/tipo-cambio.test.ts
+++ b/packages/cli/tests/unit/tipo-cambio.test.ts
@@ -81,6 +81,9 @@ describe("selectRateForDate — pure selector", () => {
 });
 
 describe("getTipoCambio — request shape", () => {
+	// SUNAT's WAF rejects the request when Accept-Encoding is absent. Bun's fetch
+	// adds the header on its own, Node's does not, so the published Node build
+	// failed on every call while the Bun-run suite stayed green.
 	test("sends Accept-Encoding, which the WAF requires", async () => {
 		const original = global.fetch;
 		let seen: Record<string, string> = {};


### PR DESCRIPTION
## Summary
- restore all valuable comments removed while aligning the tipo-cambio and SIRE fixes with repository style
- preserve SUNAT endpoint provenance, required parameters, runtime differences, smoke-test safety, and privacy boundaries
- make no runtime or published behavior changes

## Verification
- bun test packages/cli/tests/unit/tipo-cambio.test.ts packages/cli/tests/unit/sire.test.ts
- bun test packages/cli/tests/unit
- bun test --timeout 15000 packages/cli/tests/e2e
- bun run scripts/build.ts
- bash scripts/smoke-tipo-cambio.sh
- authenticated SIRE smoke verified only through its missing-credentials skip path; no live export ticket was created