### PR TITLE
docs: preserve contextual comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# sunat-cli
+
+## Comments are maintenance context
+
+- Preserve existing comments unless they are factually wrong, obsolete, or explicitly requested for removal.
+- Never remove comments merely to align code with repository style or a general preference for fewer comments.
+- Treat comments about undocumented SUNAT behavior, manual sections, production verification, required parameters, runtime differences, privacy, safety, and implementation rationale as part of the maintained contract.
+- When moving or refactoring code, move or update its contextual comments with it.
+- If a comment must be removed, preserve its still-valid context in nearby code, tests, or documentation and explain the removal in the pull request.
+- Add concise comments when surprising behavior or external evidence would otherwise be lost. Do not narrate obvious syntax.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,10 @@ bun run packages/cli/bin/sunat.ts -o json cpe doctor
 - Preserve `--dry-run`, `--yes`, intent-token, idempotency, and audit behavior when changing commands that can mutate external state.
 - Document portal assumptions and failure modes. SUNAT interfaces can change without notice.
 
+## Comments
+
+Comments that document undocumented SUNAT behavior, manual sections, production verification, required parameters, runtime differences, privacy, safety, or implementation rationale are part of the maintenance contract. Preserve them during cleanup and refactors. Move or update them with the code when needed. Remove them only when they are inaccurate, obsolete, or redundant, and preserve any still-valid context in nearby code, tests, or documentation.
+
 ## Pull requests
 
 Keep changes focused. Include the issue number, commands used for verification, any live surface tested, and known limitations. Changes to published behavior must update the README or [`packages/cli/LIMITATIONS.md`](packages/cli/LIMITATIONS.md) when relevant.


### PR DESCRIPTION
## Summary
- add repository-local agent instructions that preserve valuable contextual comments
- document the same maintenance contract for human contributors
- require useful context to move with refactors and survive style cleanups

## Verification
- git diff --check
- documentation-only change; repository CI remains the merge gate