### PR TITLE
chore(release): v0.15.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
     },
     "packages/cli": {
       "name": "@crafter/sunat-cli",
-      "version": "0.12.0",
+      "version": "0.15.1",
       "bin": {
         "sunat-cli": "dist/sunat.js",
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3849,7 +3849,7 @@
 		},
 		"packages/cli": {
 			"name": "@crafter/sunat-cli",
-			"version": "0.13.0",
+			"version": "0.15.1",
 			"license": "MIT",
 			"dependencies": {
 				"@clack/prompts": "^1.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/sunat-cli",
-	"version": "0.15.0",
+	"version": "0.15.1",
 	"description": "Agent-first CLI for SUNAT tax automation",
 	"module": "bin/sunat.ts",
 	"type": "module",


### PR DESCRIPTION
## Release
Bump @crafter/sunat-cli from 0.15.0 to 0.15.1 and synchronize both lockfiles.

## Included since v0.15.0
- fix tipo-cambio requests under the published Node runtime by sending SUNAT-required Accept-Encoding
- update SIRE proposal export, ticket polling, and downloads to current SUNAT routes and mandatory parameters
- add public tipo-cambio and credential-gated SIRE proposal smokes
- harden release reruns when the version is already published
- restore and protect valuable SUNAT implementation context

## Verification
- bun install --frozen-lockfile
- 439 unit tests passed, 1 platform skip
- 78 E2E tests passed, 2 opt-in skips
- CLI and website builds passed
- Node build reports 0.15.1 without Bun
- public tipo-cambio smoke passed
- SIRE smoke safe missing-credentials path passed
- packed tarball installed in a clean directory and reported 0.15.1