### PR TITLE
chore(release): v0.16.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
     },
     "packages/cli": {
       "name": "@crafter/sunat-cli",
-      "version": "0.15.1",
+      "version": "0.16.0",
       "bin": {
         "sunat-cli": "dist/sunat.js",
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3849,7 +3849,7 @@
 		},
 		"packages/cli": {
 			"name": "@crafter/sunat-cli",
-			"version": "0.15.1",
+			"version": "0.16.0",
 			"license": "MIT",
 			"dependencies": {
 				"@clack/prompts": "^1.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/sunat-cli",
-	"version": "0.15.1",
+	"version": "0.16.0",
 	"description": "Agent-first CLI for SUNAT tax automation",
 	"module": "bin/sunat.ts",
 	"type": "module",


### PR DESCRIPTION
## Summary

- bump @crafter/sunat-cli from 0.15.1 to 0.16.0
- release the declaraciones reader and CPE GRE schema added after v0.15.1

## Verification

- 453 unit tests passed, 1 Windows-only skip
- 88 E2E tests passed, 2 opt-in SUNAT beta skips
- npm audit and signature audit passed
- CLI and website builds passed
- mock CPE smoke passed
- package contents check passed
- clean tarball install passed under Node with Bun absent from PATH

No production tax document was submitted.