### PR TITLE
feat(website): add llms.txt for agent discovery

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -4,7 +4,9 @@
 	"version": "0.0.1",
 	"scripts": {
 		"assets": "bun run scripts/generate-assets.ts",
+		"llms": "bun run scripts/generate-llms.ts",
 		"dev": "astro dev",
+		"prebuild": "bun run scripts/generate-llms.ts",
 		"build": "astro build",
 		"preview": "astro preview"
 	},

--- a/packages/website/public/llms-full.txt
+++ b/packages/website/public/llms-full.txt
@@ -1,0 +1,581 @@
+# sunat-cli — full documentation for LLMs
+
+> SUNAT tax automation from the terminal, in Peru. Built for AI agents to operate and humans to supervise.
+
+Generated from the CLI source of truth (packages/cli/src/skills), the same manuals
+the binary serves with `sunat-cli skills get <topic>`. Do not edit by hand — run
+`bun run llms` in packages/website to regenerate.
+
+Repository: https://github.com/crafter-research/sunat-cli
+Package: https://www.npmjs.com/package/@crafter/sunat-cli
+Site: https://sunat-cli.crafter.ing
+
+---
+
+# sunat-cli
+
+SUNAT tax automation via `npx @crafter/sunat-cli` (or `sunat-cli` if globally installed).
+
+Install: `npm install -g @crafter/sunat-cli`. Runs on Node, no Bun needed.
+
+RHE uses a real browser for SOL bootstrap and final confirmation, with direct
+HTTP form transitions through the server preview. F616 and portal scrapers use
+[agent-browser](https://github.com/vercel-labs/agent-browser), which is a
+separate binary rather than a bundled dependency:
+
+```bash
+npm install -g agent-browser      # all platforms
+brew install agent-browser        # macOS
+agent-browser install             # download Chrome, first time only
+```
+
+CPE, SIRE and GRE need a SUNAT certificate and a clave SOL instead. Everything
+else works with neither.
+
+**Run `sunat-cli doctor` first.** It reports what is present, what is missing,
+and the command that fixes each gap. A command that needs agent-browser and
+cannot find it fails naming the tool and how to install it, rather than
+reporting that navigation failed.
+
+Current beta posture: supervised RHE/F616 beta, not autonomous filing. Real SUNAT operations require `--yes --live-sunat`, should use `--preview-only` first, and must stop if preview values cannot be parsed or reconciled.
+
+## Auth
+
+Three ways to provide credentials (priority order):
+
+1. **Non-secret flags**: `sunat-cli login --ruc 10XXXXXXXXX --user XXXXXXXX`
+2. **Env vars**: `SUNAT_RUC`, `SUNAT_USER`, `SUNAT_PASSWORD`
+3. **Interactive prompts**: just run `sunat-cli login` and it asks step by step
+
+```bash
+sunat-cli keychain set SUNAT_PASSWORD
+sunat-cli login --ruc 10XXXXXXXXX --user MYUSER
+sunat-cli login --nueva-plataforma --ruc 10XXXXXXXXX --user MYUSER
+sunat-cli whoami
+```
+
+RUC and usuario are saved to `~/.sunat/config.json` after first login. Password is never stored in config or another plaintext file; optional persistence uses the OS keychain.
+For non-interactive setup, pipe the secret with `sunat-cli keychain set SUNAT_PASSWORD --stdin`; it is still stored only in the OS keychain.
+
+### RHE (Recibo por Honorarios)
+
+```bash
+# Build and reconcile one RHE draft in SUNAT
+sunat-cli rhe emit --params '{
+  "empresa": "Cliente Ejemplo",
+  "tipoDoc": "SIN DOCUMENTO",
+  "descripcion": "Servicios de desarrollo de software",
+  "monto": 6700,
+  "moneda": "PEN",
+  "medioPago": "TRANSFERENCIA"
+}' --preview-only
+
+# Validate locally without opening SUNAT
+sunat-cli rhe emit --params '...' --dry-run
+
+# Reach SUNAT's server preview by direct HTTP and render it for review
+sunat-cli rhe emit --params '...' --preview-only
+
+# Emit only after visually checking the preview; XML and PDF go to Downloads/sunat-rhe
+sunat-cli rhe emit --params '...' --yes --live-sunat
+
+# Choose another private artifact directory
+sunat-cli rhe emit --params '...' --yes --live-sunat --artifacts-dir /absolute/path/rhe
+
+# Validate a CSV batch locally
+sunat-cli rhe emit --batch recibos.csv --dry-run
+```
+
+**RHE fields**: `sunat-cli skills get schemas` for the full field specs.
+
+Key rules:
+- `tipoDoc`: Only `SIN DOCUMENTO` is verified. RUC/DNI have an additional validation transition that still needs an authorized capture.
+- `moneda`: The captured HAR used PEN. Always reconcile USD with `--preview-only` before live use.
+- `fechaEmision`: the portal refuses anything older than 2 days. Measured, not
+  documented by SUNAT: no published resolution sets that limit, but the form
+  enforces it with an alert that closes on its own (invisible to snapshots; the
+  visible symptom is that the form simply does not advance).
+- `fechaEmision` is sent as `fecemi` in DD/MM/YYYY and reconciled against the rendered server preview.
+- The observed flow is `CONTADO`, non-gratuito, inciso A, no withholding and fully paid at emission.
+- Auth: headed SOL bootstrap; deduction, identity and details go by direct HTTP; final confirmation remains supervised in the browser.
+- After confirmation, the CLI posts `descargarreciboxml1` and `descargarrecibopdf1` through the same form session, validates both files and returns their private local paths. Artifact failure is reported separately from issuance status.
+- Live batches are disabled. Validate CSV with `--dry-run`, then preview and emit each RHE individually.
+
+### F616 (Monthly Tax Declaration)
+
+Two paths, and they do different things.
+
+**Reading (T0, headless):**
+
+```bash
+sunat-cli f616 periodo 2026-03      # opens a period through the API
+sunat-cli f616 oficios              # profession catalog
+```
+
+`periodo` returns the comprobantes already registered, the due date (`fec_ven`),
+the interest-rate table and the 8% rate. It is a plain HTTP call once the token
+is cached.
+
+**Filling the form (T2, needs a browser):**
+
+```bash
+sunat-cli f616 declarar estado
+sunat-cli f616 declarar periodo 2025-11
+sunat-cli f616 declarar ingreso --fecha 17/11/2025 --monto 21054 --cliente "CLIENTE EJEMPLO"
+sunat-cli f616 declarar bandeja
+sunat-cli f616 declarar constancias --dir ~/Downloads/constancias
+```
+
+This is what unlocks filing months that went by: **the F616 does not need the RHE
+to exist**. Income rows are typed into the form's own modal, which validates
+neither serie nor número against the SEE, and puts no limit on how far back the
+dates go. The electronic RHE issuer caps emission at two days; declaring never
+goes through it.
+
+Requires the F616 open in the browser (menu → Trabajadores Independientes - 616).
+
+Key rules, each one learned by hitting it:
+- **Serie is four digits, no letter.** `E001` is rejected, `0001` works.
+- **Serie, número and fecha de pago are required** despite carrying no asterisk.
+- **The month of the emission/payment date must match the open period.**
+- **Reload the form between periods.** Changing the period updates the value but
+  does not rebuild the modal's validation rules, which stay bound to the old one.
+- With tipo de documento OTROS the razón social is locked, so a company name gets
+  split across the surname fields. The record is still valid.
+- **Interest is read from casilla 553, never computed.** TIM at 0.9%/month from
+  the due date does not reproduce what SUNAT charges (S/53 vs S/124 for 11/2025).
+
+`f616 declarar` never presents or pays. It leaves the form in the tray.
+
+**The older `f616 declare`** (no accent) drives the form too but predates all of
+this. Its `ingresoPEN` and `retenciones` fields are declared in the schema and
+then ignored by the code. Prefer `declarar`.
+
+### Buzón SOL metadata
+
+```bash
+sunat-cli login
+sunat-cli buzon list --max-pages 25
+sunat-cli buzon status
+sunat-cli schema buzon
+```
+
+`buzon list` opens the legacy visor in the local SOL session, blocks the detail
+endpoint before navigation, and reads folders, alerts, messages and notification
+metadata. It does not open bodies or download attachments. Requests are
+serialized with a 1.2 second floor and a maximum of 25 pages per inbox by
+default.
+
+The command saves `~/.sunat/buzon/state.json` with owner-only permissions. The
+first run is a baseline. Later runs mark identities absent from the previous
+snapshot as new. `buzon status` reads the last snapshot without contacting
+SUNAT.
+
+SUNAT's `total`, `records` and returned rows can disagree. The JSON contract
+keeps all three observations and sets `countMismatch` instead of choosing one.
+`validUntilObserved` is upstream metadata, not a legal deadline.
+
+### Declaraciones presentadas y constancias
+
+```bash
+sunat-cli login
+sunat-cli declaraciones list --desde 01/06/2026 --hasta 27/08/2026
+sunat-cli declaraciones list --formulario 0601 --periodo 202607
+sunat-cli declaraciones constancia <numOrden> --formulario 0601 --out constancia.pdf
+sunat-cli schema declaraciones
+```
+
+`declaraciones list` opens SOL's "Consulta de declaraciones juradas y pagos"
+(menu `12.1.1.1.4`) in the local SOL session and lists every declaration and
+NPS payment presented in a date range: 0621, 0601 PLAME, 0710, 1663. SUNAT caps
+the window at six months; the default is the last 90 days. `--formulario` and
+`--periodo` filter locally. Rows are `declaracion` (link to a constancia) or
+`pago` (boleta 1663, with the `numPresentacion` it settles).
+
+`declaraciones constancia` downloads the constancia de presentación PDF for a
+número de orden. `--formulario` is required because SUNAT keys the constancia
+by (numOrden, codFor). Annual returns (0709/0710) use a different servlet and
+are not downloaded here; use `renta constancia` for the 0709.
+
+Use this to answer "what did we file for period X?" before preparing the next
+month: the PDF lists the tributos declared (5210 EsSalud, 3052 renta 5ta,
+1011 IGV, 3121 renta MYPE…) and whether the debt was paid at presentation.
+
+### API & Schema
+
+```bash
+sunat-cli api token              # Validate OAuth2 credentials without printing the token
+sunat-cli schema rhe             # JSON schema for RHE fields
+sunat-cli schema f616            # JSON schema for F616 fields
+sunat-cli schema buzon           # Metadata-only Buzón SOL contract
+sunat-cli schema declaraciones   # Read-only filings + constancia contract
+```
+
+Use `sunat-cli schema <resource>` to get machine-readable field definitions before constructing payloads.
+
+## Output Formats
+
+All commands support `--output <format>`:
+- `auto` (default): JSON when stdout is not a terminal, a human view when it is
+- `json`: JSON always
+- `table`: the human view always, even under a pipe
+
+**You do not need to pass anything.** Capturing stdout makes it non-interactive,
+so `auto` already gives you JSON. `-o json` only matters when you want JSON while
+attached to a terminal.
+
+Data goes to stdout, diagnostics to stderr. A failing command leaves stdout empty
+and reports on stderr, so `cmd > out.json` never mixes an error into the file you
+are about to parse.
+
+Some commands emit next-step hints on **stderr**, one NDJSON object per line,
+shaped `{"type":"next-step","command":"...","description":"..."}`. They tell you
+what to run next without re-planning. Ignore stderr and stdout is unchanged.
+
+Two exceptions, both deliberate: `skills get <name>` serves raw markdown rather
+than JSON, because a document escaped inside a JSON string is unreadable, and
+`--params` takes JSON *in* rather than controlling output.
+
+## Common Workflows
+
+**Monthly routine (4ta categoria)**:
+1. `sunat-cli login --nueva-plataforma`
+2. Open the F616 in the browser (menu → Trabajadores Independientes - 616)
+3. `sunat-cli f616 declarar periodo 2026-07`
+4. `sunat-cli f616 declarar ingreso --fecha 14/07/2026 --monto <bruto en soles> --cliente "<nombre>"`
+5. `sunat-cli f616 declarar estado` and check casilla 355 against your own figure
+6. `sunat-cli f616 declarar bandeja`
+7. Present and pay from the portal yourself
+
+**Filing months that went by**: same loop, one period at a time, **reloading the
+form between periods**. Eight periods spanning nine months were filed this way on
+2026-08-22 without emitting a single RHE.
+
+**Emit an RHE**:
+1. `sunat-cli login`
+2. `sunat-cli rhe emit --params '{"empresa":"Cliente Ejemplo","tipoDoc":"SIN DOCUMENTO","descripcion":"Servicios de desarrollo de software - Agosto 2026","monto":6700,"moneda":"PEN","medioPago":"TRANSFERENCIA"}' --preview-only`
+3. Check the headed browser, then rerun with `--yes --live-sunat`; the result includes the XML and PDF paths
+
+## Error Handling
+
+- Session expired: re-run `sunat-cli login`
+- `Error en la invocación`: enter Nueva Plataforma from SOL viejo, not direct URL login
+- reCAPTCHA required: keep browser flow supervised
+- Network timeout: retry, SUNAT portals are slow
+
+## More
+
+```bash
+sunat-cli skills get schemas     # field specs for RHE and F616 rows
+sunat-cli skills get endpoints   # the SUNAT endpoints behind each command
+sunat-cli skills list            # everything this version ships
+```
+
+---
+
+# SUNAT endpoints behind the CLI
+
+Measured against the portal, not from documentation. SUNAT publishes none of this.
+
+## The split that matters
+
+| Surface | Nature | How the CLI talks to it |
+|---|---|---|
+| Nueva Plataforma (`e-plataformaunica`) | JSON API | `fetch` with an `IdCache` header |
+| SOL viejo (`ol-ti-*`, `cl-ti-*`) | server-rendered | browser, no way around it |
+
+The old modules take an `hc` (hash) and a `token` (base64) in the entry URL, both
+minted by the menu's redirect. **They cannot be forged** — you have to navigate.
+
+## Nueva Plataforma: F616
+
+Base: `https://e-plataformaunica.sunat.gob.pe`
+Path: `/v1/recaudacion/tributaria/declaracion/pagoelectronico/trabajadorindependiente`
+
+| Method | Path | Purpose | Status |
+|---|---|---|---|
+| GET | `{base}/e/obtenerPeriodo/{MMYYYY}` | opens a period; returns comprobante types, TIM table, due date | observed 200 |
+| GET | `{base}/e/obtenerListaOficios` | profession catalog | observed 200 |
+| GET | `{base}/e/obtenerDatosEmpresa/{RUC}` | company lookup | observed 200 |
+| GET | `{base}/e/obtenerDatosPersona/{DNI}` | person lookup | from source |
+| GET | `{base}/e/comprobarExistenciaRecibo/{tipo}/{serie}/{numero}` | RHE existence check | from source |
+| GET | `{base}/t/consulta/obtenerSaldoAFavorPeriodoAnterior/{MMYYYY}` | prior credit | 404 on this account |
+
+`periodo` is `MMYYYY` with no separator: `112025` for November 2025.
+
+Auth: two headers on top of the session cookies.
+
+```
+IdCache: <JWT>
+IdFormulario: *MENU*
+```
+
+The JWT arrives as the `idCache` query parameter on the navigation URL, lives one
+hour, and cannot be minted headless: the portal's own client is registered for
+`authorization_code` only and its secret belongs to SUNAT.
+
+## Presentation and payment
+
+```
+POST /v1/recaudacion/tributaria/parametriapasarela/t/consulta/obtenerParametriaPasarela/
+POST /v1/recaudacion/tributaria/orquestacionpresentacion/t/consulta/validarPresentacion
+POST /v1/recaudacion/tributaria/orquestacionpresentacion/t/consulta/procesarPresentarPagar
+POST /v1/recaudacion/tributaria/orquestacionproxypago/e/registro/realizarPago
+```
+
+`obtenerParametriaPasarela` carries the whole tray:
+
+```json
+{"numPas":1,"numAplPas":"001","formularios":[
+  {"codigoFormulario":"0616","tributos":[{"codigoTributo":"030401","descTributo":"1812"}]}
+]}
+```
+
+**`procesarPresentarPagar` has never been captured.** Its body is unknown. Payment
+runs through Niubiz/Visanet on a different domain.
+
+## Tipo de cambio
+
+```
+POST https://e-consulta.sunat.gob.pe/cl-at-ittipcam/tcS01Alias/listarTipoCambio
+body: {"anio": 2025, "mes": 10, "token": "x"}
+-> [{"fecPublica":"01/11/2025","valTipo":"3.372","codTipo":"C"}, ...]
+```
+
+Three traps:
+- **`mes` is zero-indexed** (JS `getMonth()`): `mes=10` returns November.
+- **An empty `token` returns HTTP 200 with `[]`**, indistinguishable from no data.
+  Send any non-empty string; the contents are not validated.
+- The WAF rejects requests without browser-like headers. A User-Agent swap is not
+  enough: `Referer` and `Origin` are required.
+
+SUNAT publishes a rate for every calendar day, weekends included.
+
+## SOL viejo: menu codes
+
+| Code | Module |
+|---|---|
+| `11.5.1.1.2` | Emisión de RHE |
+| `11.5.1.1.13` | Consulta de RHE |
+| `55.1.3.1.5` | F616 (Nueva Plataforma) |
+| `10.11.1.1.1` | Reporte Tributario para Terceros |
+| `15.1.1.1.1` | Consulta de Valores Pendientes de Pago |
+| `12.1.1.1.4` | Consulta de Declaraciones Juradas y Pagos |
+
+### RHE emission
+
+Menu SOL action `11.5.1.1.2` mints a fresh entry URL. A direct GET of that URL
+needs no imported browser cookies and creates the RHE form session. Every later
+stage posts to `/ol-ti-itreciboelectronico/cpelec001Alias`:
+
+| Stage | `accion` |
+|---|---|
+| Deduction | `RHEDeduccion1` |
+| Identity | `CapturaDatosReciboHonorariosIdentidad` |
+| Details and server preview | `CapturaDatosReciboHonorarios` |
+| Production submission | `GrabaReciboHonorarios` |
+| Issued XML | `descargarreciboxml1` |
+| Issued PDF | `descargarrecibopdf1` |
+
+The entry URL carries six required query fields: `accion`, `p`, `tenc`, `prg`,
+`fecenv` and `usub`. Treat the whole URL as a secret. Direct HTTP is verified
+through preview for `CONTADO` + `SIN DOCUMENTO`; the final submission remains a
+browser confirmation. The confirmation HTML contains two same-endpoint POST
+forms with only the XML and PDF actions above. The original HAR did not capture
+their responses, so the CLI validates the returned XML structure and PDF
+signature before saving them. The raw HAR is private and excluded from the
+repository.
+
+### Reporte Tributario para Terceros
+
+`/ol-ti-itreportetri/reportetri.htm` → tick `#chkAceptar`, then `#btnAceptar`,
+then `?action=cargarFormulario`.
+
+`txtCorreo` is editable, so the destination can be chosen. But the form carries a
+`tokenCaptchaV3` and a Cloudflare Turnstile widget, and **both stay empty under
+CDP** — Cloudflare answers "Verification failed" even when a human solves it,
+because the browser runs with debugging flags. This one cannot be finished
+headless. Limit: 3 reports a day.
+
+### Valores Pendientes de Pago
+
+`/cl-ti-itvalores-consulta/adeudos/inicio` — fields `txtStartDate`, `txtEndDate`,
+`txtNumValor`, `btnConsultar`.
+
+Period format is `MMAAAA`, **6 characters, no slash**, and **the range cannot
+exceed 6 months**. There is no general "constancia de no adeudo" for internal
+taxes; this listing is the closest thing, and it exports to a file.
+
+## Buzón SOL metadata
+
+Base: `https://ww1.sunat.gob.pe/ol-ti-itvisornoti/visor`
+
+| Method | Path | Purpose | Status |
+|---|---|---|---|
+| GET | `/ajax/listarCarpetas` | folder metadata | observed 200 |
+| POST | `/consultarAlertas` | alert metadata | observed 200 |
+| GET | `/listNotiMenPag` | paginated messages and notifications | observed 200 |
+| GET | `/obtenerDetalleNotiMen` | body and attachments | blocked, not called by the CLI |
+
+`tipoMsj=1` selects messages and `tipoMsj=2` selects notifications. Pagination
+also sends `codCarpeta=00`, `page`, `tipoOrden=NADA`, and empty filters.
+
+The visor requests detail automatically when it loads. `buzon list` installs a
+browser route before entering the visor, so that request is blocked locally and
+cannot update read state at SUNAT. The CLI then fetches only metadata inside the
+authenticated cross-origin frame.
+
+The response fields `total`, `records` and `rows.length` are not equivalent and
+have contradicted each other live. The CLI preserves them separately.
+
+## Consulta de declaraciones juradas y pagos
+
+Base: `https://ww1.sunat.gob.pe/cl-ti-itdeclpagcon-mepeco/cdpS01Alias`, entered
+via menu `12.1.1.1.4`; the hop mints the ww1 session, a cold GET gets the login page.
+
+| Method | `accion` / path | Purpose | Status |
+|---|---|---|---|
+| POST | `accion=lista` + `fechaDesde`, `fechaHasta` (DD/MM/YYYY), empty `num_pres`, `cod_for`, `num_ord` | results table | observed 200 |
+| POST | `accion=validar_constanciaNP&num_ord=…&cod_for=0601` | `<codigo>{GUID}</codigo>`, `0` = not rendered yet | observed 200 |
+| GET | `?accion=obtener_constanciaNP&cod_ecm={GUID}` | constancia PDF | observed 200, `application/pdf` |
+| POST | `accion=ComprobanteCons` (`formulario=1663`, `numPres`, `numOrden`) | boleta detail | empty body via fetch, not used |
+| POST | `accion=obtener_reportPdf` (`num_pres`, `cod_for`, `num_ord`) | 0709/0710 constancia | from source, not used |
+| POST | `ConsultaDeclaracion.jsp` (`tamanioPagina`, `pagina`) | pagination | from source, not used |
+
+Rows link to `constanciaNP(numOrden,'0601')` for declarations and
+`comprobante('1663', numPres, '', numOrden)` for NPS boletas; the anchor, not
+the cells, is the reliable source of `numOrden` and `codFor`. Range ≤ 6 months
+(`diferenciaMayor6meses`). Measured 2026-08-27 with a RUC 20.
+
+## Login
+
+```
+GET e-menu.sunat.gob.pe/cl-ti-itmenu/MenuInternet.htm?pestana=*&agrupacion=*
+GET api-seguridad.sunat.gob.pe/v1/clientessol/4f3b88b3-.../oauth2/authen
+GET api-seguridad.sunat.gob.pe/v1/clientessol/4f3b88b3-.../oauth2/loginMenuSol
+```
+
+The SOL menu's `clientId` (`4f3b88b3-...`) differs from the Nueva Plataforma's
+(`59d39217-...`). Entering the Nueva Plataforma directly can fail with "Error en
+la invocación": it has to be reached through SOL so a valid OAuth `state` exists.
+
+Everything here was measured against the live portal between 2026-08-09 and
+2026-08-23. SUNAT documents none of it, so treat it as observation that can go
+stale rather than as a contract.
+
+---
+
+# SUNAT CLI Schemas
+
+## RHE Emit Fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| empresa | string(100) | yes | - | Company/person name receiving the service |
+| tipoDoc | enum | no | SIN DOCUMENTO | Only SIN DOCUMENTO is verified. RUC/DNI require an uncaptured validation transition. |
+| descripcion | string(200) | yes | - | Service description |
+| monto | number | yes | - | Total amount (0.01-1000000). The captured flow used PEN; preview USD before live use. |
+| moneda | enum | no | PEN | PEN or USD |
+| medioPago | enum | no | TRANSFERENCIA | DEPOSITO, GIRO, TRANSFERENCIA, ORDEN DE PAGO, TARJETA DEBITO, TARJETA CREDITO, CHEQUE, EFECTIVO |
+| fechaEmision | date | no | today | YYYY-MM-DD. Written as DD/MM/YYYY. The observed portal accepts today or the previous 2 days. |
+
+Portal: SOL viejo (e-menu.sunat.gob.pe/cl-ti-itmenu/) -- no captcha.
+
+`--dry-run` validates locally. `--preview-only` sends the stateful form endpoint
+through the server draft, renders it in the iframe and stops at the reconciled
+`Emitir Recibo` page. Submission requires `--yes --live-sunat`. A successful
+submission downloads its XML and PDF to `~/Downloads/sunat-rhe` by default;
+`--artifacts-dir <absolute-path>` changes the destination.
+
+## F616 Declare Fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| periodo | string | yes | - | YYYY-MM tax period |
+| telefono | string | no | - | Información General requires it before the other tabs unlock |
+| profesion | string | no | INGENIERO | From SUNAT's catalog (`f616 oficios`) |
+| ingresoPEN | number | no | - | **Declared in the schema, ignored by the code.** SUNAT computes from the registered rows |
+| retenciones | number | no | - | Same: ignored |
+
+**The amount is not an input.** Casilla 307 is readonly and sums the rows in the
+income table, so the figure comes from what is loaded there, not from a payload.
+
+Interest (casilla 553) is read from the form. TIM at 0.9%/month from the due date
+does not reproduce SUNAT's number: for 11/2025 it charges S/53 where the formula
+gives S/124.
+
+Portal: Nueva Plataforma (e-menu.sunat.gob.pe/cl-ti-itmenu2/), menu code 55.1.3.1.5.
+
+## GRE Emit Fields (Guía de Remisión Electrónica)
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| destinatario | object | yes | - | Goods recipient: tipoDoc (Catalog 06), numDoc, rznSocial |
+| envio | object | yes | - | Shipment: codTraslado (Catalog 20), modTraslado (Catalog 18), fecTraslado, pesoTotal, undPesoTotal, partida, llegada |
+| envio.chofer | object | cond. | - | Required when modTraslado=02: tipoDoc, nroDoc, nombres, apellidos, licencia |
+| envio.vehiculo | object | cond. | - | Required when modTraslado=02: placa (e.g. ABC-123) |
+| envio.partida | object | yes | - | Origin: ubigeo (INEI 6-digit), direccion, codLocal (default 0000) |
+| envio.llegada | object | yes | - | Destination: same shape as partida |
+| items | array | yes | - | Despatch lines: codigo, descripcion, cantidad, unidad (Catalog 03) |
+| serie | string | no | T001 | GRE serie, e.g. T001 |
+| numero | integer | yes | - | Correlative number |
+| fechaEmision | date | yes | - | YYYY-MM-DD |
+| horaEmision | string | no | 12:00:00 | HH:mm:ss |
+| observacion | string | no | - | Free-form note |
+
+Auth: OAuth credentials (SUNAT_GRE_CLIENT_ID + SUNAT_GRE_CLIENT_SECRET or SUNAT_API_*)
+plus SOL (CPE_SOL_USUARIO + CPE_SOL_PASSWORD). Get from SOL → Credenciales API SUNAT,
+URI = 'GRE Emisión de Comprobantes'.
+
+`--dry-run` builds, signs and validates locally. Submission requires `--yes`.
+Submission is asynchronous. SUNAT returns a `numTicket`. Use `--wait` to poll
+until completed/rejected, or run `sunat-cli cpe gre status --ticket <id>` later.
+
+Only modTraslado 02 (transporte privado) is implemented. modTraslado 01 (público)
+requires CarrierParty + MTC registration and is out of scope.
+
+API: REST OAuth (NOT SOAP). Different auth from Factura/Boleta.
+
+
+## Example RHE payload
+
+```json
+{
+  "empresa": "Cliente Ejemplo",
+  "tipoDoc": "SIN DOCUMENTO",
+  "descripcion": "Servicios de desarrollo de software - {MES} {AÑO}",
+  "monto": 6700,
+  "moneda": "USD",
+  "medioPago": "TRANSFERENCIA"
+}
+```
+
+## Example F616 flow
+
+There is no payload: the amount comes from a row loaded into the form.
+
+```bash
+sunat-cli f616 declarar periodo 2026-03
+sunat-cli f616 declarar ingreso --fecha 03/03/2026 --monto 21016 --cliente "CLIENTE EJEMPLO"
+sunat-cli f616 declarar estado     # casilla 355 has the figure SUNAT will charge
+sunat-cli f616 declarar bandeja
+```
+
+Income row fields (the modal's, not a CLI schema):
+
+| Field | Format | Required |
+|---|---|---|
+| Tipo de documento | RUC / DNI / OTROS | yes |
+| Serie | 4 digits, **no letter** (`0001`, not `E001`) | yes, despite no asterisk |
+| Número | 8 chars | yes, despite no asterisk |
+| Fecha emisión | DD/MM/AAAA, month must match the period | yes |
+| Fecha pago | DD/MM/AAAA | yes, despite no asterisk |
+| Monto | soles | yes |
+
+## CSV Batch Format (RHE)
+
+```csv
+empresa,tipoDoc,descripcion,monto,moneda,medioPago,fechaEmision
+"Cliente Ejemplo","SIN DOCUMENTO","Desarrollo software - Enero 2026",6700,USD,TRANSFERENCIA,2026-01-31
+"Cliente Ejemplo","SIN DOCUMENTO","Desarrollo software - Febrero 2026",6700,USD,TRANSFERENCIA,2026-02-28
+```

--- a/packages/website/public/llms.txt
+++ b/packages/website/public/llms.txt
@@ -1,0 +1,19 @@
+# sunat-cli
+
+> SUNAT tax automation from the terminal, in Peru. Built for AI agents to operate and humans to supervise. One supervised CLI over ten SUNAT surfaces — RHE, F616, CPE, SIRE, Renta, Padrón, Buzón and tipo de cambio — with JSON output, runtime schema introspection and graded safety tiers.
+
+Install with `npm install -g @crafter/sunat-cli`, then `sunat-cli --help`. The help output is the contract: every command it prints exists in the version you have. Runs on Node.
+
+## Docs
+- [Full documentation](https://sunat-cli.crafter.ing/llms-full.txt): the complete manual in one file — auth, every command surface, the SUNAT endpoint behind each command, and field schemas.
+- [README](https://github.com/crafter-research/sunat-cli/blob/main/README.md): install, quick start, the command table and safety tiers.
+- [LIMITATIONS](https://github.com/crafter-research/sunat-cli/blob/main/packages/cli/LIMITATIONS.md): the single source of truth for what does not work yet.
+
+## Source
+- [GitHub repository](https://github.com/crafter-research/sunat-cli)
+- [npm package](https://www.npmjs.com/package/@crafter/sunat-cli)
+
+## Notes
+- Output is JSON whenever stdout is not a terminal, so an agent gets parseable data without passing a flag.
+- `sunat-cli schema <command>` returns field specs at runtime, so an agent never parses `--help`.
+- Every mutation is graded: T0 read-only, T1 writes locally, T2 files with SUNAT and requires `--yes`, T3 is irreversible.

--- a/packages/website/scripts/generate-llms.ts
+++ b/packages/website/scripts/generate-llms.ts
@@ -1,0 +1,68 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// The website serves agent-facing docs from the CLI's own source of truth, the
+// same manuals the binary prints with `sunat-cli skills get <topic>`. Generating
+// them here means the published llms.txt can never drift from the shipped CLI.
+const SKILLS = join(import.meta.dir, "..", "..", "cli", "src", "skills");
+const OUT = join(import.meta.dir, "..", "public");
+
+const SITE = "https://sunat-cli.crafter.ing";
+const REPO = "https://github.com/crafter-research/sunat-cli";
+const NPM = "https://www.npmjs.com/package/@crafter/sunat-cli";
+
+// Reading order for the concatenated manual: the overview first, then the
+// endpoints behind each command, then the field schemas.
+const TOPICS = ["core", "endpoints", "schemas"];
+
+function readTopic(topic: string): string {
+	return readFileSync(join(SKILLS, `${topic}.md`), "utf8").trim();
+}
+
+function buildLlmsFull(): string {
+	const header = `# sunat-cli — full documentation for LLMs
+
+> SUNAT tax automation from the terminal, in Peru. Built for AI agents to operate and humans to supervise.
+
+Generated from the CLI source of truth (packages/cli/src/skills), the same manuals
+the binary serves with \`sunat-cli skills get <topic>\`. Do not edit by hand — run
+\`bun run llms\` in packages/website to regenerate.
+
+Repository: ${REPO}
+Package: ${NPM}
+Site: ${SITE}`;
+
+	const body = TOPICS.map(readTopic).join("\n\n---\n\n");
+	return `${header}\n\n---\n\n${body}\n`;
+}
+
+function buildLlms(): string {
+	return `# sunat-cli
+
+> SUNAT tax automation from the terminal, in Peru. Built for AI agents to operate and humans to supervise. One supervised CLI over ten SUNAT surfaces — RHE, F616, CPE, SIRE, Renta, Padrón, Buzón and tipo de cambio — with JSON output, runtime schema introspection and graded safety tiers.
+
+Install with \`npm install -g @crafter/sunat-cli\`, then \`sunat-cli --help\`. The help output is the contract: every command it prints exists in the version you have. Runs on Node.
+
+## Docs
+- [Full documentation](${SITE}/llms-full.txt): the complete manual in one file — auth, every command surface, the SUNAT endpoint behind each command, and field schemas.
+- [README](${REPO}/blob/main/README.md): install, quick start, the command table and safety tiers.
+- [LIMITATIONS](${REPO}/blob/main/packages/cli/LIMITATIONS.md): the single source of truth for what does not work yet.
+
+## Source
+- [GitHub repository](${REPO})
+- [npm package](${NPM})
+
+## Notes
+- Output is JSON whenever stdout is not a terminal, so an agent gets parseable data without passing a flag.
+- \`sunat-cli schema <command>\` returns field specs at runtime, so an agent never parses \`--help\`.
+- Every mutation is graded: T0 read-only, T1 writes locally, T2 files with SUNAT and requires \`--yes\`, T3 is irreversible.
+`;
+}
+
+function main(): void {
+	writeFileSync(join(OUT, "llms-full.txt"), buildLlmsFull());
+	writeFileSync(join(OUT, "llms.txt"), buildLlms());
+	console.log("Generated public/llms.txt and public/llms-full.txt");
+}
+
+main();


### PR DESCRIPTION
## What

Adds agent-facing documentation served from the site root:

- `public/llms.txt` — a curated index in the [llmstxt.org](https://llmstxt.org) format.
- `public/llms-full.txt` — the full manual in a single file.

Both are generated by `scripts/generate-llms.ts` from the CLI source of truth (`packages/cli/src/skills/{core,endpoints,schemas}.md`), the same manuals the binary serves with `sunat-cli skills get <topic>`. A `prebuild` step regenerates them on every website build, so the published docs cannot drift from the shipped CLI.

## Why

Part of #106. An AI agent can read the project without installing the CLI, at `https://sunat-cli.crafter.ing/llms.txt`.

## Scope

Covers the `/llms.txt` (agent-facing) half of #106 only; the `/docs` (human-facing) half is intentionally left for a follow-up. No CLI code is touched.

## Verification

- Generator output validated with Node and both files reviewed by hand.
- The website build (`npm run build`, which runs the `prebuild` generator under bun) runs in CI on this PR.
- No visual UI change — this adds static text endpoints, so there are no screenshots.
