### PR TITLE
ci: add live SUNAT smoke workflow

### DIFF
--- a/.github/workflows/smoke-live.yml
+++ b/.github/workflows/smoke-live.yml
@@ -1,0 +1,75 @@
+name: Live SUNAT smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9 * * *"
+  pull_request:
+    paths:
+      - ".github/workflows/smoke-live.yml"
+      - "packages/cli/scripts/smoke-tipo-cambio.sh"
+      - "packages/cli/scripts/smoke-ruc-online.sh"
+      - "packages/cli/src/browser/**"
+      - "packages/cli/src/commands/tipo-cambio.ts"
+      - "packages/cli/src/commands/padron/**"
+      - "packages/cli/src/sunat-rest/tipo-cambio.ts"
+      - "packages/cli/src/sunat-rest/ruc-portal.ts"
+
+jobs:
+  live-smoke:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.15.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: 1.3.11
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --registry https://registry.npmjs.org
+      - name: Install agent-browser and Chrome
+        run: |
+          npm install --global agent-browser@0.35.0 --ignore-scripts --registry https://registry.npmjs.org
+          agent-browser install
+      - name: Smoke tipo de cambio
+        run: bash scripts/smoke-tipo-cambio.sh
+        working-directory: packages/cli
+      - name: Smoke RUC online
+        run: bash scripts/smoke-ruc-online.sh
+        working-directory: packages/cli
+
+  alert:
+    needs: live-smoke
+    if: always() && github.event_name == 'schedule' && needs.live-smoke.result == 'failure'
+    permissions:
+      contents: read
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open alert issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="Live SUNAT smoke failure"
+          existing=$(gh issue list \
+            --repo "$REPO" \
+            --state open \
+            --search "$title in:title" \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Open alert already exists: #$existing"
+            exit 0
+          fi
+          gh issue create \
+            --repo "$REPO" \
+            --title "$title" \
+            --body "The scheduled live SUNAT smoke failed. @Railly please inspect the workflow run: $RUN_URL"

--- a/packages/cli/scripts/smoke-ruc-online.sh
+++ b/packages/cli/scripts/smoke-ruc-online.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Smoke test: query a known public RUC through the live SUNAT portal.
+# Requires agent-browser + its installed Chrome runtime.
+#
+# Run from packages/cli directory:
+#   bash scripts/smoke-ruc-online.sh
+#
+# No credentials needed: Consulta RUC is public.
+
+set -euo pipefail
+
+export SUNAT_HOME="$(mktemp -d "${TMPDIR:-/tmp}/sunat-smoke-ruc.XXXXXX")"
+trap 'rm -rf "$SUNAT_HOME"' EXIT
+
+KNOWN_RUC="20131312955"
+
+echo "→ bun run bin/sunat.ts padron ruc-online $KNOWN_RUC..."
+RESULT=$(bun run bin/sunat.ts -o json padron ruc-online "$KNOWN_RUC" 2>&1 || true)
+echo "$RESULT" | bun -e '
+const r = JSON.parse(await Bun.stdin.text());
+if (r.success === false) {
+  console.log("  error:", r.error);
+  console.log("\n❌ RUC-ONLINE SMOKE FAILED");
+  process.exit(1);
+}
+console.log("  found:", r.found);
+console.log("  ruc:", r.ruc);
+console.log("  razonSocial:", r.razonSocial);
+const ok =
+  r.found === true &&
+  r.ruc === "20131312955" &&
+  typeof r.razonSocial === "string" &&
+  r.razonSocial.toUpperCase().includes("SUNAT");
+if (ok) {
+  console.log("\n✅ RUC-ONLINE SMOKE PASSED");
+  process.exit(0);
+}
+console.log("\n❌ RUC-ONLINE SMOKE FAILED: known SUNAT RUC did not match expected identity");
+process.exit(1);
+'

--- a/packages/cli/scripts/smoke-tipo-cambio.sh
+++ b/packages/cli/scripts/smoke-tipo-cambio.sh
@@ -39,10 +39,14 @@ if (r.success === false) {
 console.log("  fecha:", r.fecha);
 console.log("  compra:", r.compra);
 console.log("  venta:", r.venta);
-if (typeof r.venta === "number" && r.venta > 0) {
+const reasonable =
+  typeof r.compra === "number" && r.compra > 1 && r.compra < 10 &&
+  typeof r.venta === "number" && r.venta > 1 && r.venta < 10 &&
+  Math.abs(r.compra - r.venta) < 0.5;
+if (reasonable) {
   console.log("\n✅ TIPO-CAMBIO SMOKE PASSED");
   process.exit(0);
 }
-console.log("\n❌ TIPO-CAMBIO SMOKE FAILED: no venta rate in response");
+console.log("\n❌ TIPO-CAMBIO SMOKE FAILED: unreasonable USD/PEN response");
 process.exit(1);
 '


### PR DESCRIPTION
## Summary

Implements the live CI smoke coverage requested in #16:

* adds `.github/workflows/smoke-live.yml`
* installs `agent-browser@0.35.0` + Chrome on the dedicated live-smoke job
* runs daily, manually, and on PRs touching the scraper paths
* strengthens `smoke-tipo-cambio.sh` with reasonable USD/PEN assertions
* adds a live `padron ruc-online 20131312955` smoke assertion against SUNAT
* opens a deduplicated alert issue on scheduled failures
* scopes `issues: write` only to the scheduled alert job

## Verification

Local contract checks before opening this draft:

* `pytest -q tests/test_issue16_contract.py` → 3 passed
* `bash -n` on both smoke scripts → passed
* YAML parse of the workflow → passed

The environment used to prepare this PR has no outbound DNS, so the GitHub Actions run is the first live SUNAT verification gate.

## Follow-up in this draft

Once the live smoke is green, I’ll flip the two relevant `LIMITATIONS.md` entries from untested to verified, so the documentation reflects evidence from CI rather than anticipation.

Closes #16
